### PR TITLE
systemd unit file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,17 +31,21 @@ BUILDDIR = build
 EXPORTER_BIN = $(EXPORTER)
 EXPORTER_BUILD = $(BUILDDIR)/$(EXPORTER_BIN)
 EXPORTER_INSTALL = $(DESTDIR)$(SBINDIR)/$(EXPORTER_BIN)
+EXPORTER_SERVICE_BUILD = $(BUILDDIR)/$(EXPORTER).service
+EXPORTER_SERVICE_INSTALL = $(DESTDIR)/usr/lib/systemd/system/$(EXPORTER).service
 
 GD2STATEDIR = $(LOCALSTATEDIR)/glusterd2
 GD1STATEDIR = $(LOCALSTATEDIR)/glusterd
 EXPORTER_LOGDIR = $(LOGDIR)/$(EXPORTER)
 EXPORTER_RUNDIR = $(RUNDIR)/$(EXPORTER)
 
+GLUSTER_MGMT ?= "glusterd1"
+
 DEPENV ?=
 
 FASTBUILD ?= yes
 
-.PHONY: all build binaries check check-go check-reqs install vendor-update vendor-install verify release check-protoc $(EXPORTER_BIN) $(EXPORTER_BUILD) test dist dist-vendor
+.PHONY: all build binaries check check-go check-reqs install vendor-update vendor-install verify release check-protoc $(EXPORTER_BIN) $(EXPORTER_BUILD) test dist dist-vendor gen-service
 
 all: build
 
@@ -56,7 +60,7 @@ check-reqs:
 	@./scripts/check-reqs.sh
 	@echo
 
-$(EXPORTER_BIN): $(EXPORTER_BUILD)
+$(EXPORTER_BIN): $(EXPORTER_BUILD) gen-service
 $(EXPORTER_BUILD):
 	FASTBUILD=$(FASTBUILD) BASE_PREFIX=$(BASE_PREFIX) GD1STATEDIR=$(GD1STATEDIR) \
 		GD2STATEDIR=$(GD2STATEDIR) ./scripts/build.sh $(EXPORTER)
@@ -64,6 +68,7 @@ $(EXPORTER_BUILD):
 
 install:
 	install -D $(EXPORTER_BUILD) $(EXPORTER_INSTALL)
+	install -D -m 0644 $(EXPORTER_SERVICE_BUILD) $(EXPORTER_SERVICE_INSTALL)
 	@echo
 
 vendor-update:
@@ -87,3 +92,6 @@ dist:
 
 dist-vendor: vendor-install
 	@VENDOR=yes DISTDIR=$(DISTDIR) SIGN=$(SIGN) ./scripts/dist.sh
+
+gen-service:
+	SBINDIR=$(SBINDIR) GLUSTER_MGMT=$(GLUSTER_MGMT) ./scripts/gen-service.sh

--- a/scripts/gen-service.sh
+++ b/scripts/gen-service.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+OUTDIR=${1:-build}
+mkdir -p "$OUTDIR"
+
+OUTPUT=$OUTDIR/gluster-exporter.service
+
+ARGS=""
+if [ "$GLUSTER_MGMT" == "glusterd2" ];then
+    ARGS+="--gluster-mgmt=glusterd2"
+fi
+
+cat >"$OUTPUT" <<EOF
+[Unit]
+Description=Gluster Prometheus Exporter
+
+[Service]
+ExecStart=${SBINDIR}/gluster-exporter ${ARGS}
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+
+EOF


### PR DESCRIPTION
`GLUSTER_MGMT` env variable can be used to control the systemd
unit file generation

To generate unit file to work with glusterd1

```
make
make install
```

To generate unit file to work with glusterd2

```
GLUSTER_MGMT=glusterd2 make
make install
```

Signed-off-by: Aravinda VK <avishwan@redhat.com>