### PR TITLE
Fixed to assign Glusterd2Endpoint in case gluster-mgmt value is glusterd2

### DIFF
--- a/gluster-exporter/main.go
+++ b/gluster-exporter/main.go
@@ -78,6 +78,12 @@ func main() {
 	mgmt, exists := conf.SystemConfig["gluster-mgmt"]
 	if exists {
 		glusterConfig.GlusterMgmt = mgmt
+		if mgmt == "glusterd2" {
+			endpoint, exists := conf.SystemConfig["gd2-rest-endpoint"]
+			if exists {
+				glusterConfig.Glusterd2Endpoint = endpoint
+			}
+		}
 	}
 	glusterConfig.GlusterdWorkdir = getDefaultGlusterdDir(glusterConfig.GlusterMgmt)
 	gddir, exists := conf.SystemConfig["glusterd-dir"]


### PR DESCRIPTION
Earlier it was always set as localhost and doesnt work properly if explicitly
IP of the node is set in REST endpoint

Signed-off-by: Shubhendu <shtripat@redhat.com>