### PR TITLE
gluster interface for gd1 and gd2

### DIFF
--- a/gluster-exporter/main.go
+++ b/gluster-exporter/main.go
@@ -28,6 +28,7 @@ var (
 	config                        = flag.String("config", defaultConfFile, "Config file path")
 	defaultInterval time.Duration = 5
 	glusterConfig   glusterutils.Config
+	gluster         glusterutils.GInterface
 )
 
 type glusterMetric struct {
@@ -83,6 +84,7 @@ func main() {
 	if exporterConf.GlobalConf.GlusterdDir != "" {
 		glusterConfig.GlusterdWorkdir = exporterConf.GlobalConf.GlusterdDir
 	}
+	gluster = glusterutils.MakeGluster(&glusterConfig)
 
 	// start := time.Now()
 

--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -129,14 +129,14 @@ func diskUsage(path string) (disk DiskStatus, err error) {
 }
 
 func brickUtilization() {
-	volumes, err := glusterutils.VolumeInfo(&glusterConfig)
+	volumes, err := gluster.VolumeInfo()
 	if err != nil {
 		// TODO: Log error
 		// Return without exporting metric in this cycle
 		return
 	}
 
-	localPeerID, err := glusterutils.LocalPeerID(&glusterConfig)
+	localPeerID, err := gluster.LocalPeerID()
 	if err != nil {
 		// TODO: Log error
 		// Return without exporting metric in this cycle

--- a/gluster-exporter/metric_ps.go
+++ b/gluster-exporter/metric_ps.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gluster/gluster-prometheus/pkg/glusterutils"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -86,7 +84,7 @@ func getCmdLine(pid string) ([]string, error) {
 
 func getGlusterdLabels(cmd string, args []string) (prometheus.Labels, error) {
 
-	peerID, err := glusterutils.LocalPeerID(&glusterConfig)
+	peerID, err := gluster.LocalPeerID()
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +104,7 @@ func getGlusterFsdLabels(cmd string, args []string) (prometheus.Labels, error) {
 	prevArg := ""
 
 	// TODO: Handle error
-	peerID, err := glusterutils.LocalPeerID(&glusterConfig)
+	peerID, err := gluster.LocalPeerID()
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +129,7 @@ func getGlusterFsdLabels(cmd string, args []string) (prometheus.Labels, error) {
 func getUnknownLabels(cmd string, args []string) (prometheus.Labels, error) {
 
 	// TODO: Handle error
-	peerID, err := glusterutils.LocalPeerID(&glusterConfig)
+	peerID, err := gluster.LocalPeerID()
 	if err != nil {
 		return nil, err
 	}

--- a/gluster-exporter/metric_volume_counts.go
+++ b/gluster-exporter/metric_volume_counts.go
@@ -52,7 +52,7 @@ func getVolumeLabels(volname string) prometheus.Labels {
 }
 
 func volumeCounts() {
-	volumes, err := glusterutils.VolumeInfo(&glusterConfig)
+	volumes, err := gluster.VolumeInfo()
 	if err != nil {
 		// TODO: Log error
 		return
@@ -89,7 +89,7 @@ func init() {
 	prometheus.MustRegister(glusterVolumeBrickCount)
 
 	// Name, Callback Func, Interval Seconds
-	isLeader, err := glusterutils.IsLeader(&glusterConfig)
+	isLeader, err := gluster.IsLeader()
 	if !isLeader || err != nil {
 		// Unable to find out if the current node is leader
 		// Cannot register volume metrics at this node

--- a/pkg/glusterutils/gd1.go
+++ b/pkg/glusterutils/gd1.go
@@ -1,0 +1,73 @@
+package glusterutils
+
+import (
+	"encoding/xml"
+)
+
+type gd1Brick struct {
+	Name      string `xml:"name"`
+	PeerID    string `xml:"hostUuid"`
+	IsArbiter int    `xml:"IsArbiter"`
+}
+
+type gd1Option struct {
+	Name  string `xml:"name"`
+	Value string `xml:"value"`
+}
+
+type gd1Transport string
+
+type gd1Volume struct {
+	Name                    string       `xml:"name"`
+	ID                      string       `xml:"id"`
+	Status                  string       `xml:"statusStr"`
+	Type                    string       `xml:"typeStr"`
+	Bricks                  []gd1Brick   `xml:"bricks>brick"`
+	NumBricks               int          `xml:"brickCount"`
+	DistCount               int          `xml:"distCount"`
+	ReplicaCount            int          `xml:"replicaCount"`
+	DisperseCount           int          `xml:"disperseCount"`
+	DisperseRedundancyCount int          `xml:"redundancyCount"`
+	StripeCount             int          `xml:"stripeCount"`
+	TransportRaw            gd1Transport `xml:"transport"`
+	Options                 []gd1Option  `xml:"options>option"`
+}
+
+type gd1Volumes struct {
+	XMLName xml.Name    `xml:"cliOutput"`
+	List    []gd1Volume `xml:"volInfo>volumes>volume"`
+}
+
+func (t *gd1Transport) String() string {
+	// 0 - tcp
+	// 1 - rdma
+	// 2 - tcp,rdma
+	if *t == "0" {
+		return "tcp"
+	} else if *t == "1" {
+		return "rdma"
+	}
+	return "tcp,rdma"
+}
+
+func getSubvolType(voltype string) string {
+	switch voltype {
+	case VolumeTypeDistReplicate:
+		return SubvolTypeReplicate
+	case VolumeTypeDistDisperse:
+		return SubvolTypeDisperse
+	default:
+		return voltype
+	}
+}
+
+func getSubvolBricksCount(replicaCount int, disperseCount int) int {
+	if replicaCount > 0 {
+		return replicaCount
+	}
+
+	if disperseCount > 0 {
+		return disperseCount
+	}
+	return 1
+}

--- a/pkg/glusterutils/peers_gd1.go
+++ b/pkg/glusterutils/peers_gd1.go
@@ -18,11 +18,11 @@ type peersGlusterd1 struct {
 	List    []peerGlusterd1 `xml:"peerStatus>peer"`
 }
 
-// PeersGD1 returns the list of peers ( for GlusterD1 )
-func peersGD1(config *Config) ([]Peer, error) {
+// Peers returns the list of peers ( for GlusterD1 )
+func (g *GD1) Peers() ([]Peer, error) {
 	var gd1Peers peersGlusterd1
 	var peersgd1 []Peer
-	out, err := exec.Command(config.GlusterCmd, "pool", "list", "--xml").Output()
+	out, err := exec.Command(g.config.GlusterCmd, "pool", "list", "--xml").Output()
 	if err != nil {
 		return peersgd1, err
 	}

--- a/pkg/glusterutils/peers_gd2.go
+++ b/pkg/glusterutils/peers_gd2.go
@@ -8,10 +8,10 @@ var (
 	peers api.PeerListResp
 )
 
-// PeersGD2 returns the list of peers ( for GlusterD2 )
-func peersGD2(config *Config) ([]Peer, error) {
+// Peers returns the list of peers ( for GlusterD2 )
+func (g *GD2) Peers() ([]Peer, error) {
 	var peersgd2 []Peer
-	client, err := initRESTClient(config)
+	client, err := initRESTClient(g.config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/glusterutils/types.go
+++ b/pkg/glusterutils/types.go
@@ -95,3 +95,22 @@ type Volume struct {
 	DisperseRedundancyCount int               `json:"disperse-redundancy-count"`
 	ReplicaCount            int               `json:"replica-count"`
 }
+
+// GInterface should be implemented in GD1 and GD2 structs
+type GInterface interface {
+	Peers() ([]Peer, error)
+	LocalPeerID() (string, error)
+	IsLeader() (bool, error)
+	//	HealInfo(vol string) ([]HealEntry, error)
+	VolumeInfo() ([]Volume, error)
+}
+
+// GD1 enables users to interact with gd1 version
+type GD1 struct {
+	config *Config
+}
+
+// GD2 is struct to interact with Glusterd2 using REST API
+type GD2 struct {
+	config *Config
+}

--- a/pkg/glusterutils/volinfo_gd1.go
+++ b/pkg/glusterutils/volinfo_gd1.go
@@ -7,77 +7,10 @@ import (
 	"strings"
 )
 
-type gd1Brick struct {
-	Name      string `xml:"name"`
-	PeerID    string `xml:"hostUuid"`
-	IsArbiter int    `xml:"IsArbiter"`
-}
-
-type gd1Option struct {
-	Name  string `xml:"name"`
-	Value string `xml:"value"`
-}
-
-type gd1Transport string
-
-type gd1Volume struct {
-	Name                    string       `xml:"name"`
-	ID                      string       `xml:"id"`
-	Status                  string       `xml:"statusStr"`
-	Type                    string       `xml:"typeStr"`
-	Bricks                  []gd1Brick   `xml:"bricks>brick"`
-	NumBricks               int          `xml:"brickCount"`
-	DistCount               int          `xml:"distCount"`
-	ReplicaCount            int          `xml:"replicaCount"`
-	DisperseCount           int          `xml:"disperseCount"`
-	DisperseRedundancyCount int          `xml:"redundancyCount"`
-	StripeCount             int          `xml:"stripeCount"`
-	TransportRaw            gd1Transport `xml:"transport"`
-	Options                 []gd1Option  `xml:"options>option"`
-}
-
-type gd1Volumes struct {
-	XMLName xml.Name    `xml:"cliOutput"`
-	List    []gd1Volume `xml:"volInfo>volumes>volume"`
-}
-
-func (t *gd1Transport) String() string {
-	// 0 - tcp
-	// 1 - rdma
-	// 2 - tcp,rdma
-	if *t == "0" {
-		return "tcp"
-	} else if *t == "1" {
-		return "rdma"
-	}
-	return "tcp,rdma"
-}
-
-func getSubvolType(voltype string) string {
-	switch voltype {
-	case VolumeTypeDistReplicate:
-		return SubvolTypeReplicate
-	case VolumeTypeDistDisperse:
-		return SubvolTypeDisperse
-	default:
-		return voltype
-	}
-}
-
-func getSubvolBricksCount(replicaCount int, disperseCount int) int {
-	if replicaCount > 0 {
-		return replicaCount
-	}
-
-	if disperseCount > 0 {
-		return disperseCount
-	}
-	return 1
-}
-
-func gd1VolumeInfo(config *Config) ([]Volume, error) {
+// VolumeInfo returns gluster vol info (glusterd)
+func (g *GD1) VolumeInfo() ([]Volume, error) {
 	// Run Gluster volume info --xml
-	out, err := exec.Command(config.GlusterCmd, "volume", "info", "--xml").Output()
+	out, err := exec.Command(g.config.GlusterCmd, "volume", "info", "--xml").Output()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/glusterutils/volinfo_gd2.go
+++ b/pkg/glusterutils/volinfo_gd2.go
@@ -11,8 +11,9 @@ var subvolTypeValueToName = map[api.SubvolType]string{
 	api.SubvolDisperse:   "Disperse",
 }
 
-func gd2VolumeInfo(config *Config) ([]Volume, error) {
-	client, err := initRESTClient(config)
+// VolumeInfo returns gluster vol info (glusterd2)
+func (g *GD2) VolumeInfo() ([]Volume, error) {
+	client, err := initRESTClient(g.config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
added interface to run specific cmds against gd1 and gd2
gd1.go has gd1 related functions, gd2 has glusterd2 related functions
glusterutils.go has interface which gd1 and gd2 has to implement

Signed-off-by: venkata edara <redara@redhat.com>