### PR TITLE
Added LVM usage metrics

### DIFF
--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -1,6 +1,13 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/gluster/gluster-prometheus/pkg/glusterutils"
@@ -30,6 +37,48 @@ var (
 		{
 			Name: "subvolume",
 			Help: "Sub Volume name",
+		},
+	}
+
+	subvolLabels = []MetricLabel{
+		{
+			Name: "volume",
+			Help: "Volume Name",
+		},
+		{
+			Name: "subvolume",
+			Help: "Sub volume name",
+		},
+	}
+
+	lvmLbls = []MetricLabel{
+		{
+			Name: "host",
+			Help: "Host name or IP",
+		},
+		{
+			Name: "id",
+			Help: "Brick ID",
+		},
+		{
+			Name: "brick_path",
+			Help: "Brick Path",
+		},
+		{
+			Name: "volume",
+			Help: "Volume Name",
+		},
+		{
+			Name: "subvolume",
+			Help: "Sub Volume name",
+		},
+		{
+			Name: "vg_name",
+			Help: "VG Name",
+		},
+		{
+			Name: "lv_path",
+			Help: "LV Path",
 		},
 	}
 
@@ -81,23 +130,44 @@ var (
 		Labels:    brickLabels,
 	})
 
-	subvolLabels = []MetricLabel{
-		{
-			Name: "volume",
-			Help: "Volume Name",
-		},
-		{
-			Name: "subvolume",
-			Help: "Sub volume name",
-		},
-	}
-
 	glusterSubvolCapacityUsed = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "subvol_capacity_used_bytes",
 		Help:      "Effective used capacity of gluster subvolume in bytes",
 		LongHelp:  "",
 		Labels:    subvolLabels,
+	})
+
+	glusterBrickLVSize = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "brick_lv_size_bytes",
+		Help:      "Bricks LV size Bytes",
+		LongHelp:  "",
+		Labels:    lvmLbls,
+	})
+
+	glusterBrickLVPercent = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "brick_lv_percent",
+		Help:      "Bricks LV usage percent",
+		LongHelp:  "",
+		Labels:    lvmLbls,
+	})
+
+	glusterBrickLVMetadataSize = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "brick_lv_metadata_size_bytes",
+		Help:      "Bricks LV metadata size Bytes",
+		LongHelp:  "",
+		Labels:    lvmLbls,
+	})
+
+	glusterBrickLVMetadataPercent = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "brick_lv_metadata_percent",
+		Help:      "Bricks LV metadata usage percent",
+		LongHelp:  "",
+		Labels:    lvmLbls,
 	})
 )
 
@@ -141,6 +211,179 @@ func diskUsage(path string) (disk DiskStatus, err error) {
 	disk.InodesFree = float64(fs.Ffree)
 	disk.InodesUsed = disk.InodesAll - disk.InodesFree
 	return
+}
+
+// LVMStat represents LVM details
+type LVMStat struct {
+	Device          string
+	UUID            string
+	Name            string
+	DataPercent     float64
+	PoolLV          string
+	Attr            string
+	Size            float64
+	Path            string
+	MetadataSize    float64
+	MetadataPercent float64
+	VGName          string
+}
+
+// VGReport represents VG details
+type VGReport struct {
+	Report []VGs `json:"report"`
+}
+
+// VGs represents list VG Details
+type VGs struct {
+	Vgs []VGDetails `json:"vg"`
+}
+
+// VGDetails represents a single VG detail
+type VGDetails struct {
+	LVUUID          string `json:"lv_uuid"`
+	LVName          string `json:"lv_name"`
+	DataPercent     string `json:"data_percent"`
+	PoolLV          string `json:"pool_lv"`
+	LVAttr          string `json:"lv_attr"`
+	LVSize          string `json:"lv_size"`
+	LVPath          string `json:"lv_path"`
+	LVMetadataSize  string `json:"lv_metadata_size"`
+	MetadataPercent string `json:"metadata_percent"`
+	VGName          string `json:"vg_name"`
+}
+
+func getLVS() ([]LVMStat, error) {
+	cmd := "lvm vgs --unquoted --reportformat=json --noheading --nosuffix --units m -o lv_uuid,lv_name,data_percent,pool_lv,lv_attr,lv_size,lv_path,lv_metadata_size,metadata_percent,vg_name"
+
+	out, err := exec.Command("sh", "-c", cmd).Output()
+	lvmDet := []LVMStat{}
+	if err != nil {
+		log.WithError(err).Error("Error getting lvm usage details")
+		return lvmDet, err
+	}
+	var vgReport VGReport
+	if err1 := json.Unmarshal(out, &vgReport); err1 != nil {
+		log.WithError(err1).Error("Error parsing lvm usage details")
+		return lvmDet, err1
+	}
+
+	for _, vg := range vgReport.Report[0].Vgs {
+		var obj LVMStat
+		obj.UUID = vg.LVUUID
+		obj.Name = vg.LVName
+		if vg.DataPercent == "" {
+			obj.DataPercent = 0.0
+		} else {
+			if obj.DataPercent, err = strconv.ParseFloat(vg.DataPercent, 64); err != nil {
+				log.WithError(err).Error("Error parsing DataPercent value of lvm usage")
+				return lvmDet, err
+			}
+		}
+		obj.PoolLV = vg.PoolLV
+		obj.Attr = vg.LVAttr
+		if vg.LVSize == "" {
+			obj.Size = 0.0
+		} else {
+			if obj.Size, err = strconv.ParseFloat(vg.LVSize, 64); err != nil {
+				log.WithError(err).Error("Error parsing LVSize value of lvm usage")
+				return lvmDet, err
+			}
+		}
+		obj.Path = vg.LVPath
+		if vg.LVMetadataSize == "" {
+			obj.MetadataSize = 0.0
+		} else {
+			if obj.MetadataSize, err = strconv.ParseFloat(vg.LVMetadataSize, 64); err != nil {
+				log.WithError(err).Error("Error parsing LVMetadataSize value of lvm usage")
+				return lvmDet, err
+			}
+		}
+		if vg.MetadataPercent == "" {
+			obj.MetadataPercent = 0.0
+		} else {
+			obj.MetadataPercent, err = strconv.ParseFloat(vg.MetadataPercent, 64)
+			if err != nil {
+				log.WithError(err).Error("Error parsing MetadataPercent value of lvm usage")
+				return lvmDet, err
+			}
+		}
+		obj.VGName = vg.VGName
+		if obj.Attr[0] == 't' {
+			obj.Device = fmt.Sprintf("%s/%s", obj.VGName, obj.Name)
+		} else {
+			obj.Device, err = filepath.EvalSymlinks(obj.Path)
+			if err != nil {
+				log.WithError(err).WithFields(log.Fields{
+					"path": obj.Path,
+				}).Error("Error evaluating realpath")
+				return lvmDet, err
+			}
+		}
+		lvmDet = append(lvmDet, obj)
+	}
+	return lvmDet, nil
+}
+
+// ProcMounts represents list of items from /proc/mounts
+type ProcMounts struct {
+	Name         string
+	Device       string
+	FSType       string
+	MountOptions string
+}
+
+func parseProcMounts() ([]ProcMounts, error) {
+	procMounts := []ProcMounts{}
+	b, err := ioutil.ReadFile("/proc/mounts")
+	if err != nil {
+		return procMounts, err
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(line, "/") {
+			tokens := strings.Fields(line)
+			procMounts = append(procMounts,
+				ProcMounts{Name: tokens[1], Device: tokens[0], FSType: tokens[2], MountOptions: tokens[3]})
+		}
+	}
+	return procMounts, nil
+}
+
+func getGlusterLVMLabels(brick glusterutils.Brick, subvol string, stat LVMStat) prometheus.Labels {
+	return prometheus.Labels{
+		"host":       brick.Host,
+		"id":         brick.ID,
+		"brick_path": brick.Path,
+		"volume":     brick.VolumeName,
+		"subvolume":  subvol,
+		"vg_name":    stat.VGName,
+		"lv_path":    stat.Path,
+	}
+}
+
+func lvmUsage(path string) (stats []LVMStat, err error) {
+	mountPoints, err := parseProcMounts()
+	if err != nil {
+		return stats, err
+	}
+	lvs, err := getLVS()
+	if err != nil {
+		return stats, err
+	}
+	for _, lv := range lvs {
+		for _, mount := range mountPoints {
+			dev, err := filepath.EvalSymlinks(mount.Device)
+			if err != nil {
+				log.WithError(err).WithFields(log.Fields{
+					"path": mount.Device,
+				}).Error("Error evaluating realpath")
+				continue
+			}
+			if lv.Device == dev {
+				stats = append(stats, lv)
+			}
+		}
+	}
+	return stats, nil
 }
 
 func brickUtilization() error {
@@ -189,6 +432,25 @@ func brickUtilization() error {
 					// are down
 					if brick.Type != glusterutils.BrickTypeArbiter && usage.Used >= maxBrickUsed {
 						maxBrickUsed = usage.Used
+					}
+					// Get lvm usage details
+					stats, err := lvmUsage(brick.Path)
+					if err != nil {
+						log.WithError(err).WithFields(log.Fields{
+							"volume":     volume.Name,
+							"brick_path": brick.Path,
+						}).Error("Error getting lvm usage")
+						continue
+					}
+					// Add metrics
+					for _, stat := range stats {
+						var lvmLbls = getGlusterLVMLabels(brick, subvol.Name, stat)
+						// Convert to bytes
+						glusterBrickLVSize.With(lvmLbls).Set(stat.Size * 1024 * 1024)
+						glusterBrickLVPercent.With(lvmLbls).Set(stat.DataPercent)
+						// Convert to bytes
+						glusterBrickLVMetadataSize.With(lvmLbls).Set(stat.MetadataSize * 1024 * 1024)
+						glusterBrickLVMetadataPercent.With(lvmLbls).Set(stat.MetadataPercent)
 					}
 				}
 			}


### PR DESCRIPTION
- gluster_brick_lv_size
- gluster_brick_lv_percent
- gluster_brick_lv_metadata_size
- gluster_brick_lv_metadata_percent

A snippet for metrics is as below

```
gluster_brick_lv_metadata_percent{brick_path="/root/gluster_bricks/vol1_b3",host="....",id="4252f846-eec5-4863-8b82-cf6ffc31c57a",instance="....:8080",job="prometheus",lv_path="/dev/centos_dhcp..../root",subvolume="vol1-replicate-0",vg_name="centos_dhcp....",volume="vol1"}	0
gluster_brick_lv_metadata_size{brick_path="/root/gluster_bricks/vol1_b3",host="....",id="4252f846-eec5-4863-8b82-cf6ffc31c57a",instance="....:8080",job="prometheus",lv_path="/dev/centos_dhcp..../root",subvolume="vol1-replicate-0",vg_name="centos_dhcp....",volume="vol1"}	0
gluster_brick_lv_percent{brick_path="/root/gluster_bricks/vol1_b3",host="....",id="4252f846-eec5-4863-8b82-cf6ffc31c57a",instance="....:8080",job="prometheus",lv_path="/dev/centos_dhcp..../root",subvolume="vol1-replicate-0",vg_name="centos_dhcp....",volume="vol1"}	0
gluster_brick_lv_size{brick_path="/root/gluster_bricks/vol1_b3",host="....",id="4252f846-eec5-4863-8b82-cf6ffc31c57a",instance="....:8080",job="prometheus",lv_path="/dev/centos_dhcp..../root",subvolume="vol1-replicate-0",vg_name="centos_dhcp....",volume="vol1"}	48120
```

Signed-off-by: Shubhendu <shtripat@redhat.com>