### PR TITLE
Added logic to enable profiling for volumes

### DIFF
--- a/pkg/glusterutils/enable_profile_gd1.go
+++ b/pkg/glusterutils/enable_profile_gd1.go
@@ -1,0 +1,26 @@
+package glusterutils
+
+import (
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// EnableVolumeProfiling enables profiling for a volume
+func (g *GD1) EnableVolumeProfiling(volume Volume) error {
+	value, exists := volume.Options[CountFOPHitsGD1]
+	if !exists {
+		// Enable profiling for the volumes as its not set
+		_, err := exec.Command(g.config.GlusterCmd, "volume", "profile", volume.Name, "start").Output()
+		if err != nil {
+			return err
+		}
+	} else {
+		if value == "off" {
+			log.WithFields(log.Fields{
+				"volume": volume.Name,
+			}).Debug("Volume profiling is explicitly disabled. No profile metrics would be exposed.")
+		}
+	}
+	return nil
+}

--- a/pkg/glusterutils/enable_profile_gd2.go
+++ b/pkg/glusterutils/enable_profile_gd2.go
@@ -1,0 +1,41 @@
+package glusterutils
+
+import (
+	"github.com/gluster/glusterd2/pkg/api"
+	log "github.com/sirupsen/logrus"
+)
+
+// EnableVolumeProfiling enables profiling for a volume
+func (g *GD2) EnableVolumeProfiling(volume Volume) error {
+	client, err := initRESTClient(g.config)
+	if err != nil {
+		return err
+	}
+
+	value, exists := volume.Options[CountFOPHitsGD2]
+	if !exists {
+		// Enable profiling for the volumes as its not set
+		err := client.VolumeSet(
+			volume.Name,
+			api.VolOptionReq{
+				Options: map[string]string{
+					CountFOPHitsGD2:       "on",
+					LatencyMeasurementGD2: "on",
+				},
+				VolOptionFlags: api.VolOptionFlags{
+					AllowAdvanced: true,
+				},
+			},
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		if value == "off" {
+			log.WithFields(log.Fields{
+				"volume": volume.Name,
+			}).Debug("Volume profiling is explicitly disabled. No profile metrics would be exposed.")
+		}
+	}
+	return nil
+}

--- a/pkg/glusterutils/types.go
+++ b/pkg/glusterutils/types.go
@@ -33,6 +33,15 @@ const (
 	VolumeStateStarted = "Started"
 	// VolumeStateStopped represents Volume stopped state
 	VolumeStateStopped = "Stopped"
+
+	// CountFOPHitsGD1 represents volume option name for fop hits counts
+	CountFOPHitsGD1 = "diagnostics.count-fop-hits"
+	// LatencyMeasurementGD1 represents volume option for latency measurement
+	LatencyMeasurementGD1 = "diagnostics.latency-measurement"
+	// CountFOPHitsGD2 represents volume option name for fop hits counts
+	CountFOPHitsGD2 = "debug/io-stats.count-fop-hits"
+	// LatencyMeasurementGD2 represents volume option for latency measurement
+	LatencyMeasurementGD2 = "debug/io-stats.latency-measurement"
 )
 
 // Config represents Glusterd1/Glusterd2 configurations
@@ -132,6 +141,7 @@ type GInterface interface {
 	Snapshots() ([]Snapshot, error)
 	VolumeProfileInfo(vol string) ([]ProfileInfo, error)
 	VolumeBrickStatus(vol string) ([]BrickStatus, error)
+	EnableVolumeProfiling(volinfo Volume) error
 }
 
 // FopStat defines file ops related details


### PR DESCRIPTION
If `gluster_volume_profile` metrics collector is enabled and explicitly
for a volume the profiling is not disabled, it will enable profiling
for the volume so that profile specific metrics could be exposed.

Fixes: gluster/gluster-prometheus/issues/90
Signed-off-by: Shubhendu <shtripat@redhat.com>