### PR TITLE
Added interval stats metrics for volume profile info

### DIFF
--- a/docs/metrics.adoc
+++ b/docs/metrics.adoc
@@ -450,6 +450,30 @@ Thin pool metadata used Bytes
 
 |===
 
+== gluster_brick_up
+
+Brick up (1-up, 0-down)
+
+|===
+|Label|Description
+
+|volume
+|Volume Name
+
+|hostname
+|Host name or IP
+
+|brick_path
+|Brick Path
+
+|peer_id
+|Peer ID
+
+|pid
+|Process ID of brick
+
+|===
+
 == gluster_pv_count
 
 No: of Physical Volumes
@@ -684,9 +708,54 @@ Duration
 
 |===
 
+== gluster_volume_profile_total_reads_interval
+
+Total no of reads for interval stats
+
+|===
+|Label|Description
+
+|volume
+|Volume name
+
+|brick
+|Brick Name
+
+|===
+
+== gluster_volume_profile_total_writes_interval
+
+Total no of writes for interval stats
+
+|===
+|Label|Description
+
+|volume
+|Volume name
+
+|brick
+|Brick Name
+
+|===
+
+== gluster_volume_profile_duration_secs_interval
+
+Duration for interval stats
+
+|===
+|Label|Description
+
+|volume
+|Volume name
+
+|brick
+|Brick Name
+
+|===
+
 == gluster_volume_profile_fop_hits
 
-Duration
+Cumulative FOP hits
 
 |===
 |Label|Description
@@ -707,7 +776,7 @@ Duration
 
 == gluster_volume_profile_fop_avg_latency
 
-Duration
+Cumulative FOP avergae latency
 
 |===
 |Label|Description
@@ -728,7 +797,7 @@ Duration
 
 == gluster_volume_profile_fop_min_latency
 
-Duration
+Cumulative FOP min latency
 
 |===
 |Label|Description
@@ -749,7 +818,91 @@ Duration
 
 == gluster_volume_profile_fop_max_latency
 
-Duration
+Cumulative FOP max latency
+
+|===
+|Label|Description
+
+|volume
+|Volume name
+
+|brick
+|Brick Name
+
+|host
+|Hostname or IP
+
+|fop
+|File Operation name
+
+|===
+
+== gluster_volume_profile_fop_hits_interval
+
+Interval based FOP hits
+
+|===
+|Label|Description
+
+|volume
+|Volume name
+
+|brick
+|Brick Name
+
+|host
+|Hostname or IP
+
+|fop
+|File Operation name
+
+|===
+
+== gluster_volume_profile_fop_avg_latency_interval
+
+Interval based FOP average latency
+
+|===
+|Label|Description
+
+|volume
+|Volume name
+
+|brick
+|Brick Name
+
+|host
+|Hostname or IP
+
+|fop
+|File Operation name
+
+|===
+
+== gluster_volume_profile_fop_min_latency_interval
+
+Interval based FOP min latency
+
+|===
+|Label|Description
+
+|volume
+|Volume name
+
+|brick
+|Brick Name
+
+|host
+|Hostname or IP
+
+|fop
+|File Operation name
+
+|===
+
+== gluster_volume_profile_fop_max_latency_interval
+
+Interval based FOP max latency
 
 |===
 |Label|Description
@@ -807,6 +960,18 @@ Total count of snapshots bricks for volume
 == gluster_volume_snapshot_brick_count_active
 
 Total active count of snapshots bricks for volume
+
+|===
+|Label|Description
+
+|volume
+|Volume Name
+
+|===
+
+== gluster_volume_up
+
+Volume is started or not (1-started, 0-not started)
 
 |===
 |Label|Description

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -67,6 +67,30 @@ var (
 		Labels:    volumeProfileInfoLabels,
 	})
 
+	glusterVolumeProfileTotalReadsInt = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_profile_total_reads_interval",
+		Help:      "Total no of reads for interval stats",
+		LongHelp:  "",
+		Labels:    volumeProfileInfoLabels,
+	})
+
+	glusterVolumeProfileTotalWritesInt = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_profile_total_writes_interval",
+		Help:      "Total no of writes for interval stats",
+		LongHelp:  "",
+		Labels:    volumeProfileInfoLabels,
+	})
+
+	glusterVolumeProfileDurationInt = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_profile_duration_secs_interval",
+		Help:      "Duration for interval stats",
+		LongHelp:  "",
+		Labels:    volumeProfileInfoLabels,
+	})
+
 	volumeProfileFopInfoLabels = []MetricLabel{
 		{
 			Name: "volume",
@@ -89,7 +113,7 @@ var (
 	glusterVolumeProfileFopHits = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_hits",
-		Help:      "Duration",
+		Help:      "Cumulative FOP hits",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
 	})
@@ -97,7 +121,7 @@ var (
 	glusterVolumeProfileFopAvgLatency = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_avg_latency",
-		Help:      "Duration",
+		Help:      "Cumulative FOP avergae latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
 	})
@@ -105,7 +129,7 @@ var (
 	glusterVolumeProfileFopMinLatency = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_min_latency",
-		Help:      "Duration",
+		Help:      "Cumulative FOP min latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
 	})
@@ -113,7 +137,39 @@ var (
 	glusterVolumeProfileFopMaxLatency = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_max_latency",
-		Help:      "Duration",
+		Help:      "Cumulative FOP max latency",
+		LongHelp:  "",
+		Labels:    volumeProfileFopInfoLabels,
+	})
+
+	glusterVolumeProfileFopHitsInt = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_profile_fop_hits_interval",
+		Help:      "Interval based FOP hits",
+		LongHelp:  "",
+		Labels:    volumeProfileFopInfoLabels,
+	})
+
+	glusterVolumeProfileFopAvgLatencyInt = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_profile_fop_avg_latency_interval",
+		Help:      "Interval based FOP average latency",
+		LongHelp:  "",
+		Labels:    volumeProfileFopInfoLabels,
+	})
+
+	glusterVolumeProfileFopMinLatencyInt = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_profile_fop_min_latency_interval",
+		Help:      "Interval based FOP min latency",
+		LongHelp:  "",
+		Labels:    volumeProfileFopInfoLabels,
+	})
+
+	glusterVolumeProfileFopMaxLatencyInt = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_profile_fop_max_latency_interval",
+		Help:      "Interval based FOP max latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
 	})
@@ -219,6 +275,9 @@ func profileInfo() error {
 			glusterVolumeProfileTotalReads.With(labels).Set(float64(entry.TotalReads))
 			glusterVolumeProfileTotalWrites.With(labels).Set(float64(entry.TotalWrites))
 			glusterVolumeProfileDuration.With(labels).Set(float64(entry.Duration))
+			glusterVolumeProfileTotalReadsInt.With(labels).Set(float64(entry.TotalReadsInt))
+			glusterVolumeProfileTotalWritesInt.With(labels).Set(float64(entry.TotalWritesInt))
+			glusterVolumeProfileDurationInt.With(labels).Set(float64(entry.DurationInt))
 			brickhost := getBrickHost(volume, entry.BrickName)
 			for _, fopInfo := range entry.FopStats {
 				fopLbls := getVolumeProfileFopInfoLabels(name, entry.BrickName, brickhost, fopInfo.Name)
@@ -226,6 +285,13 @@ func profileInfo() error {
 				glusterVolumeProfileFopAvgLatency.With(fopLbls).Set(fopInfo.AvgLatency)
 				glusterVolumeProfileFopMinLatency.With(fopLbls).Set(fopInfo.MinLatency)
 				glusterVolumeProfileFopMaxLatency.With(fopLbls).Set(fopInfo.MaxLatency)
+			}
+			for _, fopInfo := range entry.FopStatsInt {
+				fopLbls := getVolumeProfileFopInfoLabels(name, entry.BrickName, brickhost, fopInfo.Name)
+				glusterVolumeProfileFopHitsInt.With(fopLbls).Set(float64(fopInfo.Hits))
+				glusterVolumeProfileFopAvgLatencyInt.With(fopLbls).Set(fopInfo.AvgLatency)
+				glusterVolumeProfileFopMinLatencyInt.With(fopLbls).Set(fopInfo.MinLatency)
+				glusterVolumeProfileFopMaxLatencyInt.With(fopLbls).Set(fopInfo.MaxLatency)
 			}
 		}
 	}

--- a/pkg/glusterutils/gd1.go
+++ b/pkg/glusterutils/gd1.go
@@ -99,9 +99,18 @@ type cumulativeStats struct {
 	FopStats   []gd1FopStat `xml:"fopStats>fop"`
 }
 
+type intervalStats struct {
+	BlkStats   []blockStat  `xml:"blokcStats>block"`
+	Duration   uint64       `xml:"duration"`
+	TotalRead  uint64       `xml:"totalRead"`
+	TotalWrite uint64       `xml:"totalWrite"`
+	FopStats   []gd1FopStat `xml:"fopStats>fop"`
+}
+
 type brickProfileInfo struct {
-	Name  string          `xml:"brickName"`
-	Stats cumulativeStats `xml:"cumulativeStats"`
+	Name     string          `xml:"brickName"`
+	Stats    cumulativeStats `xml:"cumulativeStats"`
+	IntStats intervalStats   `xml:"intervalStats"`
 }
 
 type volumeProfile struct {

--- a/pkg/glusterutils/profileinfo_gd1.go
+++ b/pkg/glusterutils/profileinfo_gd1.go
@@ -7,8 +7,8 @@ import (
 
 // VolumeProfileInfo returns profile info details for the volume
 func (g *GD1) VolumeProfileInfo(vol string) ([]ProfileInfo, error) {
-	// Run Gluster volume profile <volname> info umulative --xml
-	out, err := exec.Command(g.config.GlusterCmd, "volume", "profile", vol, "info", "cumulative", "--xml").Output()
+	// Run Gluster volume profile <volname> info --xml
+	out, err := exec.Command(g.config.GlusterCmd, "volume", "profile", vol, "info", "--xml").Output()
 	if err != nil {
 		return nil, err
 	}
@@ -22,17 +22,28 @@ func (g *GD1) VolumeProfileInfo(vol string) ([]ProfileInfo, error) {
 	profileinfo := make([]ProfileInfo, len(info.VolProfile.Bricks))
 	for idx, brick := range info.VolProfile.Bricks {
 		obj := ProfileInfo{
-			BrickName:   brick.Name,
-			Duration:    brick.Stats.Duration,
-			TotalReads:  brick.Stats.TotalRead,
-			TotalWrites: brick.Stats.TotalWrite,
+			BrickName:      brick.Name,
+			Duration:       brick.Stats.Duration,
+			TotalReads:     brick.Stats.TotalRead,
+			TotalWrites:    brick.Stats.TotalWrite,
+			DurationInt:    brick.IntStats.Duration,
+			TotalReadsInt:  brick.IntStats.TotalRead,
+			TotalWritesInt: brick.IntStats.TotalWrite,
 		}
+
 		if brick.Stats.FopStats != nil {
 			fopStats := make([]FopStat, len(brick.Stats.FopStats))
 			for idx1, stat := range brick.Stats.FopStats {
 				fopStats[idx1] = FopStat(stat)
 			}
 			obj.FopStats = fopStats
+		}
+		if brick.IntStats.FopStats != nil {
+			intFopStats := make([]FopStat, len(brick.IntStats.FopStats))
+			for idx1, stat := range brick.IntStats.FopStats {
+				intFopStats[idx1] = FopStat(stat)
+			}
+			obj.FopStatsInt = intFopStats
 		}
 		profileinfo[idx] = obj
 	}

--- a/pkg/glusterutils/profileinfo_gd2.go
+++ b/pkg/glusterutils/profileinfo_gd2.go
@@ -61,6 +61,35 @@ func (g *GD2) VolumeProfileInfo(vol string) ([]ProfileInfo, error) {
 			}
 			obj.FopStats = fopStats
 		}
+		if info.IntervalStats.StatsInfo != nil {
+			fopStats := make([]FopStat, len(info.IntervalStats.StatsInfo))
+			for fopName, stat := range info.IntervalStats.StatsInfo {
+				var hits int
+				var avgLatency, minLatency, maxLatency float64
+				if hits, err = strconv.Atoi(stat["hits"]); err != nil {
+					hits = 0
+				}
+				if avgLatency, err = strconv.ParseFloat(stat["avglatency"], 10); err != nil {
+					avgLatency = 0.0
+				}
+				if minLatency, err = strconv.ParseFloat(stat["minlatency"], 10); err != nil {
+					minLatency = 0.0
+				}
+				if maxLatency, err = strconv.ParseFloat(stat["maxlatency"], 10); err != nil {
+					maxLatency = 0.0
+				}
+
+				fopStat := FopStat{
+					Name:       fopName,
+					Hits:       hits,
+					AvgLatency: avgLatency,
+					MinLatency: minLatency,
+					MaxLatency: maxLatency,
+				}
+				fopStats = append(fopStats, fopStat)
+			}
+			obj.FopStatsInt = fopStats
+		}
 		profileinfo[idx] = obj
 	}
 

--- a/pkg/glusterutils/types.go
+++ b/pkg/glusterutils/types.go
@@ -145,11 +145,15 @@ type FopStat struct {
 
 // ProfileInfo represents volume profile info brickwise
 type ProfileInfo struct {
-	BrickName   string
-	Duration    uint64
-	TotalReads  uint64
-	TotalWrites uint64
-	FopStats    []FopStat
+	BrickName      string
+	Duration       uint64
+	TotalReads     uint64
+	TotalWrites    uint64
+	FopStats       []FopStat
+	DurationInt    uint64
+	TotalReadsInt  uint64
+	TotalWritesInt uint64
+	FopStatsInt    []FopStat
 }
 
 // GD1 enables users to interact with gd1 version


### PR DESCRIPTION
Added below metrics
- gluster_volume_profile_total_reads_interval
- gluster_volume_profile_total_writes_interval
- gluster_volume_profile_duration_secs_interval
- gluster_volume_profile_fop_hits_interval
- gluster_volume_profile_fop_avg_latency_interval
- gluster_volume_profile_fop_min_latency_interval
- gluster_volume_profile_fop_max_latency_interval

Fixes: gluster/gluster-prometheus/issues/101
Signed-off-by: Shubhendu <shtripat@redhat.com>