### PR TITLE
Added LV UUID in labels for lvm metrics

### DIFF
--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -80,6 +80,10 @@ var (
 			Name: "lv_path",
 			Help: "LV Path",
 		},
+		{
+			Name: "lv_uuid",
+			Help: "UUID of LV",
+		},
 	}
 
 	brickStatusLbls = []MetricLabel{
@@ -510,6 +514,7 @@ func getGlusterLVMLabels(brick glusterutils.Brick, subvol string, stat LVMStat) 
 		"subvolume":  subvol,
 		"vg_name":    stat.VGName,
 		"lv_path":    stat.Path,
+		"lv_uuid":    stat.UUID,
 	}
 }
 


### PR DESCRIPTION
This is required to uniquely identify the LVs for the bricks.

Fixes: gluster/gluster-prometheus/issues/114
Signed-off-by: Shubhendu <shtripat@redhat.com>