### PR TITLE
Changed the log severity to Debug

### DIFF
--- a/gluster-exporter/main.go
+++ b/gluster-exporter/main.go
@@ -137,7 +137,7 @@ func main() {
 						if err != nil {
 							log.WithError(err).WithFields(log.Fields{
 								"name": m.name,
-							}).Error("failed to export metric")
+							}).Debug("failed to export metric")
 						}
 						time.Sleep(time.Second * interval)
 					}

--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -403,12 +403,12 @@ func getLVS() ([]LVMStat, []ThinPoolStat, error) {
 	thinPool := []ThinPoolStat{}
 	var vgExtentFreeTemp float64
 	if err != nil {
-		log.WithError(err).Error("Error getting lvm usage details")
+		log.WithError(err).Debug("Error getting lvm usage details")
 		return lvmDet, thinPool, err
 	}
 	var vgReport VGReport
 	if err1 := json.Unmarshal(out, &vgReport); err1 != nil {
-		log.WithError(err1).Error("Error parsing lvm usage details")
+		log.WithError(err1).Debug("Error parsing lvm usage details")
 		return lvmDet, thinPool, err1
 	}
 
@@ -420,7 +420,7 @@ func getLVS() ([]LVMStat, []ThinPoolStat, error) {
 			obj.DataPercent = 0.0
 		} else {
 			if obj.DataPercent, err = strconv.ParseFloat(vg.DataPercent, 64); err != nil {
-				log.WithError(err).Error("Error parsing DataPercent value of lvm usage")
+				log.WithError(err).Debug("Error parsing DataPercent value of lvm usage")
 				return lvmDet, thinPool, err
 			}
 		}
@@ -430,7 +430,7 @@ func getLVS() ([]LVMStat, []ThinPoolStat, error) {
 			obj.Size = 0.0
 		} else {
 			if obj.Size, err = strconv.ParseFloat(vg.LVSize, 64); err != nil {
-				log.WithError(err).Error("Error parsing LVSize value of lvm usage")
+				log.WithError(err).Debug("Error parsing LVSize value of lvm usage")
 				return lvmDet, thinPool, err
 			}
 		}
@@ -439,7 +439,7 @@ func getLVS() ([]LVMStat, []ThinPoolStat, error) {
 			obj.MetadataSize = 0.0
 		} else {
 			if obj.MetadataSize, err = strconv.ParseFloat(vg.LVMetadataSize, 64); err != nil {
-				log.WithError(err).Error("Error parsing LVMetadataSize value of lvm usage")
+				log.WithError(err).Debug("Error parsing LVMetadataSize value of lvm usage")
 				return lvmDet, thinPool, err
 			}
 		}
@@ -448,7 +448,7 @@ func getLVS() ([]LVMStat, []ThinPoolStat, error) {
 		} else {
 			obj.MetadataPercent, err = strconv.ParseFloat(vg.MetadataPercent, 64)
 			if err != nil {
-				log.WithError(err).Error("Error parsing MetadataPercent value of lvm usage")
+				log.WithError(err).Debug("Error parsing MetadataPercent value of lvm usage")
 				return lvmDet, thinPool, err
 			}
 		}
@@ -457,7 +457,7 @@ func getLVS() ([]LVMStat, []ThinPoolStat, error) {
 		} else {
 			obj.VGExtentTotal, err = strconv.ParseFloat(vg.VGExtentTotal, 64)
 			if err != nil {
-				log.WithError(err).Error("Error parsing VGExtenTotal value of lvm usage")
+				log.WithError(err).Debug("Error parsing VGExtenTotal value of lvm usage")
 				return lvmDet, thinPool, err
 			}
 		}
@@ -466,7 +466,7 @@ func getLVS() ([]LVMStat, []ThinPoolStat, error) {
 		} else {
 			vgExtentFreeTemp, err = strconv.ParseFloat(vg.VGExtentFree, 64)
 			if err != nil {
-				log.WithError(err).Error("Error parsing VGExtentAlloc value of lvm usage")
+				log.WithError(err).Debug("Error parsing VGExtentAlloc value of lvm usage")
 				return lvmDet, thinPool, err
 			}
 		}
@@ -487,7 +487,7 @@ func getLVS() ([]LVMStat, []ThinPoolStat, error) {
 			if err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"path": obj.Path,
-				}).Error("Error evaluating realpath")
+				}).Debug("Error evaluating realpath")
 				return lvmDet, thinPool, err
 			}
 		}
@@ -562,7 +562,7 @@ func lvmUsage(path string) (stats []LVMStat, thinPoolStats []ThinPoolStat, err e
 			if err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"path": mount.Device,
-				}).Error("Error evaluating realpath")
+				}).Debug("Error evaluating realpath")
 				continue
 			}
 			// Check if the logical volume is mounted as a gluster brick
@@ -625,7 +625,7 @@ func brickUtilization(gluster glusterutils.GInterface) error {
 						log.WithError(err).WithFields(log.Fields{
 							"volume":     volume.Name,
 							"brick_path": brick.Path,
-						}).Error("Error getting disk usage")
+						}).Debug("Error getting disk usage")
 						continue
 					}
 					var lbls = getGlusterBrickLabels(brick, subvol.Name)
@@ -653,7 +653,7 @@ func brickUtilization(gluster glusterutils.GInterface) error {
 						log.WithError(err).WithFields(log.Fields{
 							"volume":     volume.Name,
 							"brick_path": brick.Path,
-						}).Error("Error getting lvm usage")
+						}).Debug("Error getting lvm usage")
 						continue
 					}
 					// Add metrics
@@ -721,7 +721,7 @@ func brickStatus(gluster glusterutils.GInterface) error {
 	isLeader, err := gluster.IsLeader()
 
 	if err != nil {
-		log.WithError(err).Error("Unable to find if the current node is leader")
+		log.WithError(err).Debug("Unable to find if the current node is leader")
 		return err
 	}
 
@@ -756,7 +756,7 @@ func brickStatus(gluster glusterutils.GInterface) error {
 			if err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"volume": volume.Name,
-				}).Error("Error getting bricks status")
+				}).Debug("Error getting bricks status")
 				continue
 			}
 		}

--- a/gluster-exporter/metric_peer_counts.go
+++ b/gluster-exporter/metric_peer_counts.go
@@ -181,7 +181,7 @@ func peerCounts(gluster glusterutils.GInterface) (err error) {
 		// log the error and then return
 		log.WithError(err).WithFields(log.Fields{
 			"peer": peerID,
-		}).Errorln("[Peer_Metric_Count] Error:", err)
+		}).Debug("[Peer_Metric_Count] Error:", err)
 		return err
 	}
 	genrlLbls := prometheus.Labels{

--- a/gluster-exporter/metric_ps.go
+++ b/gluster-exporter/metric_ps.go
@@ -185,7 +185,7 @@ func ps(gluster glusterutils.GInterface) error {
 			log.WithError(err).WithFields(log.Fields{
 				"command": lineData[6],
 				"pid":     lineData[0],
-			}).Error("Error getting command line")
+			}).Debug("Error getting command line")
 			continue
 		}
 
@@ -199,25 +199,25 @@ func ps(gluster glusterutils.GInterface) error {
 		case "glusterd":
 			lbls, err = getGlusterdLabels(peerID, lineData[6], cmdlineArgs)
 			if err != nil {
-				log.WithError(err).Error("Unable to get glusterd labels")
+				log.WithError(err).Debug("Unable to get glusterd labels")
 				continue
 			}
 		case "glusterd2":
 			lbls, err = getGlusterdLabels(peerID, lineData[6], cmdlineArgs)
 			if err != nil {
-				log.WithError(err).Error("Unable to get glusterd2 labels")
+				log.WithError(err).Debug("Unable to get glusterd2 labels")
 				continue
 			}
 		case "glusterfsd":
 			lbls, err = getGlusterFsdLabels(peerID, lineData[6], cmdlineArgs)
 			if err != nil {
-				log.WithError(err).Error("Unable to get glusterfsd labels")
+				log.WithError(err).Debug("Unable to get glusterfsd labels")
 				continue
 			}
 		default:
 			lbls, err = getUnknownLabels(peerID, lineData[6], cmdlineArgs)
 			if err != nil {
-				log.WithError(err).Error("Unable to get default labels")
+				log.WithError(err).Debug("Unable to get default labels")
 				continue
 			}
 		}
@@ -228,7 +228,7 @@ func ps(gluster glusterutils.GInterface) error {
 				"value":   lineData[1],
 				"command": lineData[6],
 				"pid":     lineData[0],
-			}).Error("Unable to parse pcpu value")
+			}).Debug("Unable to parse pcpu value")
 			continue
 		}
 
@@ -238,7 +238,7 @@ func ps(gluster glusterutils.GInterface) error {
 				"value":   lineData[2],
 				"command": lineData[6],
 				"pid":     lineData[0],
-			}).Error("Unable to parse pmem value")
+			}).Debug("Unable to parse pmem value")
 			continue
 		}
 		rsz, err := strconv.ParseFloat(lineData[3], 64)
@@ -247,7 +247,7 @@ func ps(gluster glusterutils.GInterface) error {
 				"value":   lineData[3],
 				"command": lineData[6],
 				"pid":     lineData[0],
-			}).Error("Unable to parse rsz value")
+			}).Debug("Unable to parse rsz value")
 			continue
 		}
 
@@ -257,7 +257,7 @@ func ps(gluster glusterutils.GInterface) error {
 				"value":   lineData[4],
 				"command": lineData[6],
 				"pid":     lineData[0],
-			}).Error("Unable to parse vsz value")
+			}).Debug("Unable to parse vsz value")
 			continue
 		}
 
@@ -267,7 +267,7 @@ func ps(gluster glusterutils.GInterface) error {
 				"value":   lineData[5],
 				"command": lineData[6],
 				"pid":     lineData[0],
-			}).Error("Unable to parse etimes value")
+			}).Debug("Unable to parse etimes value")
 			continue
 		}
 

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -319,7 +319,7 @@ func healCounts(gluster glusterutils.GInterface) error {
 	if err != nil {
 		// Unable to find out if the current node is leader
 		// Cannot register volume metrics at this node
-		log.WithError(err).Error("Unable to find if the current node is leader")
+		log.WithError(err).Debug("Unable to find if the current node is leader")
 		return err
 	}
 	if !isLeader {
@@ -343,7 +343,7 @@ func healCounts(gluster glusterutils.GInterface) error {
 		if err != nil {
 			log.WithError(err).WithFields(log.Fields{
 				"volume": volName,
-			}).Error(errStr)
+			}).Debug(errStr)
 			return
 		}
 		for _, healinfo := range heals {
@@ -404,7 +404,7 @@ func profileInfo(gluster glusterutils.GInterface) error {
 	isLeader, err := gluster.IsLeader()
 
 	if err != nil {
-		log.WithError(err).Error("Unable to find if the current node is leader")
+		log.WithError(err).Debug("Unable to find if the current node is leader")
 		return err
 	}
 	if !isLeader {
@@ -430,7 +430,7 @@ func profileInfo(gluster glusterutils.GInterface) error {
 		if err != nil {
 			log.WithError(err).WithFields(log.Fields{
 				"volume": volume.Name,
-			}).Error("Error enabling profiling for volume")
+			}).Debug("Error enabling profiling for volume")
 			continue
 		}
 		if value, exists := volume.Options[volOption]; !exists || value == "off" {
@@ -442,7 +442,7 @@ func profileInfo(gluster glusterutils.GInterface) error {
 		if err != nil {
 			log.WithError(err).WithFields(log.Fields{
 				"volume": name,
-			}).Error("Error getting profile info")
+			}).Debug("Error getting profile info")
 			continue
 		}
 		for _, entry := range profileinfo {

--- a/gluster-exporter/metric_volume_counts.go
+++ b/gluster-exporter/metric_volume_counts.go
@@ -91,7 +91,7 @@ func volumeCounts(gluster glusterutils.GInterface) error {
 	isLeader, err := gluster.IsLeader()
 
 	if err != nil {
-		log.WithError(err).Error("Unable to find if the current node is leader")
+		log.WithError(err).Debug("Unable to find if the current node is leader")
 		return err
 	}
 	if !isLeader {


### PR DESCRIPTION
All the logs which could happen on every execution of collectors
due to volume, bricks and other calls, now changed to Debug. This
is required to make sure /var/log doesnt get hogged due to gluster
exporter just because there are some problematic volume, bricks etc.

Fixes: gluster/gluster-prometheus/issues/126
Signed-off-by: Shubhendu <shtripat@redhat.com>