### PR TITLE
Registering function signature change

### DIFF
--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -575,7 +575,7 @@ func lvmUsage(path string) (stats []LVMStat, thinPoolStats []ThinPoolStat, err e
 	return stats, thinPoolStats, nil
 }
 
-func brickUtilization() error {
+func brickUtilization(gluster glusterutils.GInterface) error {
 	volumes, err := gluster.VolumeInfo()
 	if err != nil {
 		// Return without exporting metric in this cycle
@@ -692,7 +692,7 @@ func getBrickStatusLabels(vol string, host string, brickPath string, peerID stri
 	}
 }
 
-func brickStatus() error {
+func brickStatus(gluster glusterutils.GInterface) error {
 	isLeader, err := gluster.IsLeader()
 	if err != nil {
 		log.WithError(err).Error("Unable to find if the current node is leader")

--- a/gluster-exporter/metric_peer_counts.go
+++ b/gluster-exporter/metric_peer_counts.go
@@ -157,7 +157,7 @@ var (
 	})
 )
 
-func peerCounts() (err error) {
+func peerCounts(gluster glusterutils.GInterface) (err error) {
 	var peerID string
 	// 'gluster' is initialized inside 'main' function,
 	// so it is better to check whether it is available or not

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -292,7 +292,7 @@ func getVolumeHealLabels(volname string, host string, brick string) prometheus.L
 
 }
 
-func healCounts() error {
+func healCounts(gluster glusterutils.GInterface) error {
 	isLeader, err := gluster.IsLeader()
 
 	if err != nil {
@@ -355,7 +355,7 @@ func getBrickHost(vol glusterutils.Volume, brickname string) string {
 	return ""
 }
 
-func profileInfo() error {
+func profileInfo(gluster glusterutils.GInterface) error {
 	isLeader, err := gluster.IsLeader()
 	if err != nil {
 		log.WithError(err).Error("Unable to find if the current node is leader")

--- a/gluster-exporter/metric_volume_counts.go
+++ b/gluster-exporter/metric_volume_counts.go
@@ -78,7 +78,7 @@ func getVolumeLabels(volname string) prometheus.Labels {
 	}
 }
 
-func volumeCounts() error {
+func volumeCounts(gluster glusterutils.GInterface) error {
 	isLeader, err := gluster.IsLeader()
 	if !isLeader || err != nil {
 		// Unable to find out if the current node is leader


### PR DESCRIPTION
Changing the signature of the registering function,
from 'fn() error' to 'fn(glusterutils.GInterface) error'.
This helps (in future) to reduce a lot of global variables from passed
around.

Fixes: Issue https://github.com/gluster/gluster-prometheus/issues/100

Signed-off-by: Arun Kumar Mohan <arun.iiird@gmail.com>