### PR TITLE
Creating a gluster configuration interface

### DIFF
--- a/gluster-exporter/main.go
+++ b/gluster-exporter/main.go
@@ -31,7 +31,6 @@ var (
 	docgen                        = flag.Bool("docgen", false, "Generate exported metrics documentation in Asciidoc format")
 	config                        = flag.String("config", defaultConfFile, "Config file path")
 	defaultInterval time.Duration = 5
-	glusterConfig   glusterutils.Config
 	gluster         glusterutils.GInterface
 )
 
@@ -93,6 +92,7 @@ func main() {
 		log.WithError(err).Fatal("Failed to initialize logging")
 	}
 
+	var glusterConfig glusterutils.Config
 	// Set the Gluster Configurations used in glusterutils
 	glusterConfig.GlusterMgmt = "glusterd"
 	if exporterConf.GlobalConf.GlusterMgmt != "" {

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -370,6 +370,10 @@ func profileInfo() error {
 		return err
 	}
 	volOption := glusterutils.CountFOPHitsGD1
+	glusterConfig, err := glusterutils.GConfigFromInterface(gluster)
+	if err != nil {
+		return err
+	}
 	if glusterConfig.GlusterMgmt == glusterutils.MgmtGlusterd2 {
 		volOption = glusterutils.CountFOPHitsGD2
 	}

--- a/pkg/glusterutils/exporterd.go
+++ b/pkg/glusterutils/exporterd.go
@@ -122,6 +122,26 @@ func (g *GD2) LocalPeerID() (string, error) {
 	return readPeerID(fileStream, keywordID)
 }
 
+// Config method returns the configuration, and
+// makes it compatible with 'GConfigInterface'
+func (g *GD1) Config() *Config {
+	return g.config
+}
+
+// Config method returns the configuration, and
+// makes it compatible with 'GConfigInterface'
+func (g *GD2) Config() *Config {
+	return g.config
+}
+
+// GConfigFromInterface method returns a 'glusterutils.Config' pointer
+func GConfigFromInterface(iFace interface{}) (*Config, error) {
+	if gConfI, ok := iFace.(GConfigInterface); ok {
+		return gConfI.Config(), nil
+	}
+	return nil, errors.New("Provided interface don't implement 'GConfigInterface'")
+}
+
 // GetGlusterVersion gets the glusterfs version
 func GetGlusterVersion() (string, error) {
 	cmd := "glusterfs --version | head -1"

--- a/pkg/glusterutils/types.go
+++ b/pkg/glusterutils/types.go
@@ -144,6 +144,13 @@ type GInterface interface {
 	EnableVolumeProfiling(volinfo Volume) error
 }
 
+// GConfigInterface enables to get configuration,
+// with which the gluster management object is made of.
+// This should be implemented by both GD1 or GD2
+type GConfigInterface interface {
+	Config() *Config
+}
+
 // FopStat defines file ops related details
 type FopStat struct {
 	Name       string


### PR DESCRIPTION
'GConfigInterface' will help to eliminate any global configuration
objects being passed around.

Fixes: issue https://github.com/gluster/gluster-prometheus/issues/129
Signed-off-by: Arun Kumar Mohan <arun.iiird@gmail.com>