### PR TITLE
Adding caching mechanism to gluster-exporter

### DIFF
--- a/extras/conf/gluster-exporter.toml.sample
+++ b/extras/conf/gluster-exporter.toml.sample
@@ -9,14 +9,13 @@ log-dir = "/var/log/gluster-exporter"
 log-file = "exporter.log"
 log-level = "info"
 cache-ttl-in-sec = 30
-# by default caching is enabled only for the below functions,
-# 'IsLeader', 'LocalPeerID', 'VolumeInfo'
-#
+# by default caching is turned off
 # to enable caching, add the function-name to 'cache-enabled-funcs' list
-# other supported functions are,
+# supported functions are,
+# 'IsLeader', 'LocalPeerID', 'VolumeInfo'
 # 'EnableVolumeProfiling', 'HealInfo', 'Peers',
 # 'Snapshots', 'VolumeBrickStatus', 'VolumeProfileInfo'
-cache-enabled-funcs = []
+cache-enabled-funcs = [ 'IsLeader', 'LocalPeerID', 'VolumeInfo' ]
 
 [collectors.gluster_ps]
 name = "gluster_ps"

--- a/extras/conf/gluster-exporter.toml.sample
+++ b/extras/conf/gluster-exporter.toml.sample
@@ -8,6 +8,13 @@ metrics-path = "/metrics"
 log-dir = "/var/log/gluster-exporter"
 log-file = "exporter.log"
 log-level = "info"
+cache-ttl-in-sec = 30
+# by default all the functions are cached
+# functions which have to be disabled from caching should be added to 'cache-disabled-funcs'
+# supported functions are,
+# 'EnableVolumeProfiling', 'HealInfo', 'IsLeader', 'LocalPeerID', 'Peers',
+# 'Snapshots', 'VolumeBrickStatus', 'VolumeInfo', 'VolumeProfileInfo'
+cache-disabled-funcs = []
 
 [collectors.gluster_ps]
 name = "gluster_ps"

--- a/extras/conf/gluster-exporter.toml.sample
+++ b/extras/conf/gluster-exporter.toml.sample
@@ -8,6 +8,7 @@ metrics-path = "/metrics"
 log-dir = "/var/log/gluster-exporter"
 log-file = "exporter.log"
 log-level = "info"
+# cache-ttl-in-sec = 0, disables caching
 cache-ttl-in-sec = 30
 # by default caching is turned off
 # to enable caching, add the function-name to 'cache-enabled-funcs' list

--- a/extras/conf/gluster-exporter.toml.sample
+++ b/extras/conf/gluster-exporter.toml.sample
@@ -9,12 +9,14 @@ log-dir = "/var/log/gluster-exporter"
 log-file = "exporter.log"
 log-level = "info"
 cache-ttl-in-sec = 30
-# by default all the functions are cached
-# functions which have to be disabled from caching should be added to 'cache-disabled-funcs'
-# supported functions are,
-# 'EnableVolumeProfiling', 'HealInfo', 'IsLeader', 'LocalPeerID', 'Peers',
-# 'Snapshots', 'VolumeBrickStatus', 'VolumeInfo', 'VolumeProfileInfo'
-cache-disabled-funcs = []
+# by default caching is enabled only for the below functions,
+# 'IsLeader', 'LocalPeerID', 'VolumeInfo'
+#
+# to enable caching, add the function-name to 'cache-enabled-funcs' list
+# other supported functions are,
+# 'EnableVolumeProfiling', 'HealInfo', 'Peers',
+# 'Snapshots', 'VolumeBrickStatus', 'VolumeProfileInfo'
+cache-enabled-funcs = []
 
 [collectors.gluster_ps]
 name = "gluster_ps"

--- a/gluster-exporter/conf/conf.go
+++ b/gluster-exporter/conf/conf.go
@@ -9,15 +9,17 @@ import (
 
 // Globals maintains the global system configurations
 type Globals struct {
-	GlusterMgmt       string `toml:"gluster-mgmt"`
-	GlusterdDir       string `toml:"glusterd-dir"`
-	GlusterBinaryPath string `toml:"gluster-binary-path"`
-	GD2RESTEndpoint   string `toml:"gd2-rest-endpoint"`
-	Port              int    `toml:"port"`
-	MetricsPath       string `toml:"metrics-path"`
-	LogDir            string `toml:"log-dir"`
-	LogFile           string `toml:"log-file"`
-	LogLevel          string `toml:"log-level"`
+	GlusterMgmt        string   `toml:"gluster-mgmt"`
+	GlusterdDir        string   `toml:"glusterd-dir"`
+	GlusterBinaryPath  string   `toml:"gluster-binary-path"`
+	GD2RESTEndpoint    string   `toml:"gd2-rest-endpoint"`
+	Port               int      `toml:"port"`
+	MetricsPath        string   `toml:"metrics-path"`
+	LogDir             string   `toml:"log-dir"`
+	LogFile            string   `toml:"log-file"`
+	LogLevel           string   `toml:"log-level"`
+	CacheTTL           uint64   `toml:"cache-ttl-in-sec"`
+	CacheDisabledFuncs []string `toml:"cache-disabled-funcs"`
 }
 
 // Collectors struct defines the structure of collectors configuration

--- a/gluster-exporter/conf/conf.go
+++ b/gluster-exporter/conf/conf.go
@@ -9,17 +9,17 @@ import (
 
 // Globals maintains the global system configurations
 type Globals struct {
-	GlusterMgmt        string   `toml:"gluster-mgmt"`
-	GlusterdDir        string   `toml:"glusterd-dir"`
-	GlusterBinaryPath  string   `toml:"gluster-binary-path"`
-	GD2RESTEndpoint    string   `toml:"gd2-rest-endpoint"`
-	Port               int      `toml:"port"`
-	MetricsPath        string   `toml:"metrics-path"`
-	LogDir             string   `toml:"log-dir"`
-	LogFile            string   `toml:"log-file"`
-	LogLevel           string   `toml:"log-level"`
-	CacheTTL           uint64   `toml:"cache-ttl-in-sec"`
-	CacheDisabledFuncs []string `toml:"cache-disabled-funcs"`
+	GlusterMgmt       string   `toml:"gluster-mgmt"`
+	GlusterdDir       string   `toml:"glusterd-dir"`
+	GlusterBinaryPath string   `toml:"gluster-binary-path"`
+	GD2RESTEndpoint   string   `toml:"gd2-rest-endpoint"`
+	Port              int      `toml:"port"`
+	MetricsPath       string   `toml:"metrics-path"`
+	LogDir            string   `toml:"log-dir"`
+	LogFile           string   `toml:"log-file"`
+	LogLevel          string   `toml:"log-level"`
+	CacheTTL          uint64   `toml:"cache-ttl-in-sec"`
+	CacheEnabledFuncs []string `toml:"cache-enabled-funcs"`
 }
 
 // Collectors struct defines the structure of collectors configuration

--- a/gluster-exporter/main.go
+++ b/gluster-exporter/main.go
@@ -114,7 +114,7 @@ func main() {
 	if exporterConf.GlobalConf.GlusterdDir != "" {
 		glusterConfig.GlusterdWorkdir = exporterConf.GlobalConf.GlusterdDir
 	}
-	gluster = glusterutils.MakeGluster(&glusterConfig)
+	gluster = glusterutils.MakeGluster(&glusterConfig, exporterConf)
 
 	// start := time.Now()
 

--- a/pkg/glusterutils/cache.go
+++ b/pkg/glusterutils/cache.go
@@ -16,7 +16,8 @@ type GCache struct {
 	cacheEnabledFuncs map[string]struct{}
 }
 
-// NewGCacheWithTTL method creates a new GCache wrapper instance
+// NewGCacheWithTTL method creates a new GCache wrapper instance.
+// Caching will be disabled if ttl is ZERO
 func NewGCacheWithTTL(gd GInterface, ttl time.Duration) *GCache {
 	var gc = new(GCache)
 	gc.gd = gd
@@ -43,8 +44,8 @@ func (gc *GCache) TTL() time.Duration {
 
 // SetTTL method sets a new time_to_live
 func (gc *GCache) SetTTL(ttl time.Duration) {
-	// accepts only if the given ttl is greater than a second
-	if ttl > time.Second {
+	// accepts 0 or durations in Seconds
+	if ttl == time.Duration(0) || ttl >= time.Second {
 		gc.ttl = ttl
 	}
 }

--- a/pkg/glusterutils/cache.go
+++ b/pkg/glusterutils/cache.go
@@ -64,10 +64,10 @@ func (gc *GCache) timeForNewCall(funcName string, origFuncName string) bool {
 	if _, ok := gc.cacheDisabledFuncs[origFuncName]; ok {
 		return true
 	}
-	nowT := time.Now()
 	if _, ok := gc.lastCallTimeMap[funcName]; !ok {
 		return true
 	}
+	nowT := time.Now()
 	// if the last called time is BEFORE 'now - ttl', then call again
 	if gc.lastCallTimeMap[funcName].Before(nowT.Add(-gc.ttl)) {
 		return true

--- a/pkg/glusterutils/cache.go
+++ b/pkg/glusterutils/cache.go
@@ -24,12 +24,9 @@ func NewGCacheWithTTL(gd GInterface, ttl time.Duration) *GCache {
 	gc.SetTTL(ttl)
 	gc.lastCallValueMap = make(map[string]interface{})
 	gc.lastCallTimeMap = make(map[string]time.Time)
-	// by default we are enabling cache only for a few functions
-	gc.cacheEnabledFuncs = map[string]struct{}{
-		"IsLeader":    {},
-		"LocalPeerID": {},
-		"VolumeInfo":  {},
-	}
+	// functions for which caching have to be enabled
+	// are added to the below map
+	gc.cacheEnabledFuncs = make(map[string]struct{})
 	return gc
 }
 

--- a/pkg/glusterutils/cache.go
+++ b/pkg/glusterutils/cache.go
@@ -56,21 +56,22 @@ func (gc *GCache) DisableCacheForFuncs(fNames []string) {
 	}
 }
 
-func (gc *GCache) timeForNewCall(funcName string, origFuncName string) bool {
+func (gc *GCache) timeForNewCall(funcName string, origFuncName string) (ret bool) {
 	if origFuncName == "" {
 		origFuncName = funcName
 	}
+	ret = true
 	// if the function is disabled, always return true
 	if _, ok := gc.cacheDisabledFuncs[origFuncName]; ok {
-		return true
+		return
 	}
 	if _, ok := gc.lastCallTimeMap[funcName]; !ok {
-		return true
+		return
 	}
 	nowT := time.Now()
 	// if the last called time is BEFORE 'now - ttl', then call again
 	if gc.lastCallTimeMap[funcName].Before(nowT.Add(-gc.ttl)) {
-		return true
+		return
 	}
 	return false
 }

--- a/pkg/glusterutils/cache.go
+++ b/pkg/glusterutils/cache.go
@@ -1,0 +1,280 @@
+package glusterutils
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// GCache is a wrapper around 'GInterface' object
+type GCache struct {
+	gd                 GInterface
+	ttl                time.Duration
+	lock               sync.Mutex
+	lastCallValueMap   map[string]interface{}
+	lastCallTimeMap    map[string]time.Time
+	cacheDisabledFuncs map[string]struct{}
+}
+
+// NewGCacheWithTTL method creates a new GCache wrapper instance
+func NewGCacheWithTTL(gd GInterface, ttl time.Duration) *GCache {
+	var gc = new(GCache)
+	gc.gd = gd
+	gc.ttl = 1 * time.Minute // default to 1 minute
+	gc.SetTTL(ttl)
+	gc.lastCallValueMap = make(map[string]interface{})
+	gc.lastCallTimeMap = make(map[string]time.Time)
+	gc.cacheDisabledFuncs = make(map[string]struct{})
+	return gc
+}
+
+// NewGCache method creates a new GCache wrapper instance,
+// with 1 minute default time_to_live
+func NewGCache(gd GInterface) *GCache {
+	return NewGCacheWithTTL(gd, 1*time.Minute)
+}
+
+// TTL method returns the current time_to_live duration
+func (gc *GCache) TTL() time.Duration {
+	return gc.ttl
+}
+
+// SetTTL method sets a new time_to_live
+func (gc *GCache) SetTTL(ttl time.Duration) {
+	// accepts only if the given ttl is greater than a second
+	if ttl > time.Second {
+		gc.ttl = ttl
+	}
+}
+
+// DisableCacheForFuncs method will disable the caching functionalities
+// for the provided list of functions.
+// If the provided function is not there in the existing list, it will be ignored
+func (gc *GCache) DisableCacheForFuncs(fNames []string) {
+	for _, fName := range fNames {
+		gc.cacheDisabledFuncs[fName] = struct{}{}
+	}
+}
+
+func (gc *GCache) timeForNewCall(funcName string, origFuncName string) bool {
+	if origFuncName == "" {
+		origFuncName = funcName
+	}
+	// if the function is disabled, always return true
+	if _, ok := gc.cacheDisabledFuncs[origFuncName]; ok {
+		return true
+	}
+	nowT := time.Now()
+	if _, ok := gc.lastCallTimeMap[funcName]; !ok {
+		return true
+	}
+	// if the last called time is BEFORE 'now - ttl', then call again
+	if gc.lastCallTimeMap[funcName].Before(nowT.Add(-gc.ttl)) {
+		return true
+	}
+	return false
+}
+
+// EnableVolumeProfiling method wraps the GInterface.EnableVolumeProfiling call
+func (gc *GCache) EnableVolumeProfiling(vInfo Volume) error {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	const origName = "EnableVolumeProfiling"
+	// caching the result for each volume
+	var localName = origName + "-" + vInfo.ID + "-" + vInfo.Name
+	var retVal error
+	if gc.timeForNewCall(localName, origName) {
+		if retVal = gc.gd.EnableVolumeProfiling(vInfo); retVal != nil {
+			return retVal
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	return retVal
+}
+
+// HealInfo method wraps the GInterface.HealInfo call
+func (gc *GCache) HealInfo(vol string) ([]HealEntry, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	// adding the argument[s] also to the 'localName'
+	// as we want to cache the function call with each argument
+	// it will be wrong to cache the results for only one volume
+	// and show the same result throughout for other volumes
+	const origName = "HealInfo"
+	var localName = origName + "-" + vol
+	var retVal []HealEntry
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, origName) {
+		if retVal, err = gc.gd.HealInfo(vol); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].([]HealEntry); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}
+
+// IsLeader method wraps the GInterface.IsLeader call
+func (gc *GCache) IsLeader() (bool, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	const localName = "IsLeader"
+	var retVal bool
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, localName) {
+		if retVal, err = gc.gd.IsLeader(); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].(bool); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}
+
+// LocalPeerID method wraps the GInterface.LocalPeerID call
+func (gc *GCache) LocalPeerID() (string, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	const localName = "LocalPeerID"
+	var retVal string
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, localName) {
+		if retVal, err = gc.gd.LocalPeerID(); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].(string); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}
+
+// Peers method wraps the GInterface.Peers call
+func (gc *GCache) Peers() ([]Peer, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	const localName = "Peers"
+	var retVal []Peer
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, localName) {
+		if retVal, err = gc.gd.Peers(); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].([]Peer); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}
+
+// Snapshots method wraps the GInterface.Snapshots call
+func (gc *GCache) Snapshots() ([]Snapshot, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	const localName = "Snapshots"
+	var retVal []Snapshot
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, localName) {
+		if retVal, err = gc.gd.Snapshots(); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].([]Snapshot); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}
+
+// VolumeBrickStatus method wraps the GInterface.VolumeBrickStatus call
+func (gc *GCache) VolumeBrickStatus(vol string) ([]BrickStatus, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	// caching the results for each volume
+	const origName = "VolumeBrickStatus"
+	var localName = origName + "-" + vol
+	var retVal []BrickStatus
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, origName) {
+		if retVal, err = gc.gd.VolumeBrickStatus(vol); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].([]BrickStatus); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}
+
+// VolumeInfo method wraps the GInterface.VolumeInfo call
+func (gc *GCache) VolumeInfo() ([]Volume, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	const localName = "VolumeInfo"
+	var retVal []Volume
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, localName) {
+		if retVal, err = gc.gd.VolumeInfo(); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].([]Volume); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}
+
+// VolumeProfileInfo method wraps the GInterface.VolumeProfileInfo call
+func (gc *GCache) VolumeProfileInfo(vol string) ([]ProfileInfo, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	// caching the results for each volume
+	const origName = "VolumeProfileInfo"
+	var localName = origName + "-" + vol
+	var retVal []ProfileInfo
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, origName) {
+		if retVal, err = gc.gd.VolumeProfileInfo(vol); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].([]ProfileInfo); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}

--- a/pkg/glusterutils/exporterd.go
+++ b/pkg/glusterutils/exporterd.go
@@ -69,8 +69,8 @@ func (g *GD2) IsLeader() (bool, error) {
 
 // MakeGluster returns respective gluster obj based on configuration
 func MakeGluster(config *Config, expConf *conf.Config) GInterface {
-	setDefaultConfig(config)
 	var gi GInterface
+	setDefaultConfig(config)
 	gi = &GD2{config: config}
 	if config.GlusterMgmt == "" || config.GlusterMgmt == MgmtGlusterd {
 		gi = &GD1{config: config}

--- a/pkg/glusterutils/exporterd.go
+++ b/pkg/glusterutils/exporterd.go
@@ -77,7 +77,7 @@ func MakeGluster(config *Config, expConf *conf.Config) GInterface {
 	}
 	cacheTTL := time.Duration(expConf.GlobalConf.CacheTTL) * time.Second
 	cachedGI := NewGCacheWithTTL(gi, cacheTTL)
-	cachedGI.DisableCacheForFuncs(expConf.GlobalConf.CacheDisabledFuncs)
+	cachedGI.EnableCacheForFuncs(expConf.GlobalConf.CacheEnabledFuncs)
 	return cachedGI
 }
 


### PR DESCRIPTION
'GInterface' (object's) methods can now cache the results within a TTL
(time-to-live) interval. By default caching is enabled for the methods,
but can be disabled through exporter-configuration file.

Fixes: #125
Signed-off-by: Arun Kumar Mohan <arun.iiird@gmail.com>