### PR TITLE
Standardizing Gluster configuration handling

### DIFF
--- a/extras/conf/gluster-exporter.toml.sample
+++ b/extras/conf/gluster-exporter.toml.sample
@@ -1,4 +1,5 @@
 [globals]
+gluster-cluster-id = ""
 gluster-mgmt = "glusterd"
 glusterd-dir = "/var/lib/glusterd"
 gluster-binary-path = "gluster"

--- a/gluster-exporter/conf/conf.go
+++ b/gluster-exporter/conf/conf.go
@@ -1,18 +1,31 @@
 package conf
 
 import (
-	"io/ioutil"
+	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 )
+
+// GConfig represents Glusterd1/Glusterd2 configurations
+type GConfig struct {
+	GlusterMgmt       string `toml:"gluster-mgmt"`
+	Glusterd2Endpoint string `toml:"gd2-rest-endpoint"`
+	GlusterCmd        string `toml:"gluster-binary-path"`
+	GlusterdWorkdir   string `toml:"glusterd-dir"`
+	GlusterClusterID  string `toml:"gluster-cluster-id"`
+	Glusterd2User     string
+	Glusterd2Secret   string
+	Glusterd2Cacert   string
+	Glusterd2Insecure bool
+	Timeout           int64
+}
 
 // Globals maintains the global system configurations
 type Globals struct {
-	GlusterMgmt       string   `toml:"gluster-mgmt"`
-	GlusterdDir       string   `toml:"glusterd-dir"`
-	GlusterBinaryPath string   `toml:"gluster-binary-path"`
-	GD2RESTEndpoint   string   `toml:"gd2-rest-endpoint"`
 	Port              int      `toml:"port"`
 	MetricsPath       string   `toml:"metrics-path"`
 	LogDir            string   `toml:"log-dir"`
@@ -20,6 +33,7 @@ type Globals struct {
 	LogLevel          string   `toml:"log-level"`
 	CacheTTL          uint64   `toml:"cache-ttl-in-sec"`
 	CacheEnabledFuncs []string `toml:"cache-enabled-funcs"`
+	*GConfig
 }
 
 // Collectors struct defines the structure of collectors configuration
@@ -30,20 +44,62 @@ type Collectors struct {
 }
 
 // Config struct defines overall configurations
+// it embeds 'Globals' configuration
 type Config struct {
-	GlobalConf     Globals               `toml:"globals"`
+	*Globals       `toml:"globals"`
 	CollectorsConf map[string]Collectors `toml:"collectors"`
 }
 
+// GConfig method helps 'Config' objects to implement 'GConfigInterface'
+func (conf *Config) GConfig() *GConfig {
+	return conf.Globals.GConfig
+}
+
 // LoadConfig loads the configuration file
-func LoadConfig(confFilePath string) (*Config, error) {
-	var conf Config
-	b, err := ioutil.ReadFile(filepath.Clean(confFilePath))
-	if err != nil {
-		return nil, err
+func LoadConfig(confFilePath string) (conf *Config, err error) {
+	conf = &Config{}
+	if _, err = toml.DecodeFile(filepath.Clean(confFilePath), conf); err != nil {
+		conf = nil
+		return
 	}
-	if _, err := toml.Decode(string(b), &conf); err != nil {
-		return nil, err
+	// by default, use glusterd (that is; GD1)
+	if conf.GlusterMgmt == "" {
+		conf.GlusterMgmt = glusterconsts.MgmtGlusterd
 	}
-	return &conf, nil
+	// If GD2_ENDPOINTS env variable is set, use that info
+	// for making REST API calls
+	if endpoint := os.Getenv(glusterconsts.EnvGD2Endpoints); endpoint != "" {
+		conf.Glusterd2Endpoint = endpoint
+	}
+	// if there are multiple endpoints, get the first one
+	if endpoint := conf.Glusterd2Endpoint; endpoint != "" {
+		endpoint = strings.Replace(endpoint, ",", " ", -1)
+		endpoint = strings.Fields(endpoint)[0]
+		conf.Glusterd2Endpoint = endpoint
+	}
+	// if GLUSTER_CLUSTER_ID env variable is set, it gets the precedence
+	if gClusterID := os.Getenv(glusterconsts.EnvGlusterClusterID); gClusterID != "" {
+		conf.GlusterClusterID = gClusterID
+	}
+	// gluster cluster ID is still empty, put the default
+	if conf.GlusterClusterID == "" {
+		conf.GlusterClusterID = glusterconsts.DefaultGlusterClusterID
+	}
+	return
+}
+
+// GConfigInterface enables to get configuration,
+// with which the gluster management objects are created.
+// Should be implemented by both GD1 and GD2.
+type GConfigInterface interface {
+	GConfig() *GConfig
+}
+
+// GConfigFromInterface method returns a 'GConfig' pointer,
+// if and only if the argument interface implements 'GConfigInterface'
+func GConfigFromInterface(iFace interface{}) (*GConfig, error) {
+	if gConfig, ok := iFace.(GConfigInterface); ok {
+		return gConfig.GConfig(), nil
+	}
+	return nil, errors.New("Provided interface don't implement 'GConfigInterface'")
 }

--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/gluster/gluster-prometheus/pkg/glusterutils"
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -608,7 +609,7 @@ func brickUtilization(gluster glusterutils.GInterface) error {
 	}
 
 	for _, volume := range volumes {
-		if volume.State != glusterutils.VolumeStateStarted {
+		if volume.State != glusterconsts.VolumeStateStarted {
 			// Export brick metrics only if the Volume
 			// is is in Started state
 			continue
@@ -639,10 +640,10 @@ func brickUtilization(gluster glusterutils.GInterface) error {
 					// Skip exporting utilization data in case of arbiter
 					// brick to avoid wrong values when both the data bricks
 					// are down
-					if brick.Type != glusterutils.BrickTypeArbiter && usage.Used >= maxBrickUsed {
+					if brick.Type != glusterconsts.BrickTypeArbiter && usage.Used >= maxBrickUsed {
 						maxBrickUsed = usage.Used
 					}
-					if brick.Type != glusterutils.BrickTypeArbiter {
+					if brick.Type != glusterconsts.BrickTypeArbiter {
 						if leastBrickTotal == 0 || usage.All <= leastBrickTotal {
 							leastBrickTotal = usage.All
 						}
@@ -680,7 +681,7 @@ func brickUtilization(gluster glusterutils.GInterface) error {
 			effectiveCapacity := maxBrickUsed
 			effectiveTotalCapacity := leastBrickTotal
 			var subvolLabels = getGlusterSubvolLabels(volume.Name, subvol.Name)
-			if subvol.Type == glusterutils.SubvolTypeDisperse {
+			if subvol.Type == glusterconsts.SubvolTypeDisperse {
 				// In disperse volume data bricks contribute to the sub
 				// volume size
 				effectiveCapacity = maxBrickUsed * float64(subvol.DisperseDataCount)
@@ -737,7 +738,7 @@ func brickStatus(gluster glusterutils.GInterface) error {
 	for _, volume := range volumes {
 		// If volume is down, the bricks should be marked down
 		var brickStatus []glusterutils.BrickStatus
-		if volume.State != glusterutils.VolumeStateStarted {
+		if volume.State != glusterconsts.VolumeStateStarted {
 			for _, subvol := range volume.SubVolumes {
 				for _, brick := range subvol.Bricks {
 					status := glusterutils.BrickStatus{

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/gluster/gluster-prometheus/gluster-exporter/conf"
 	"github.com/gluster/gluster-prometheus/pkg/glusterutils"
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
@@ -415,9 +417,13 @@ func profileInfo(gluster glusterutils.GInterface) error {
 	if err != nil {
 		return err
 	}
-	volOption := glusterutils.CountFOPHitsGD1
-	if glusterConfig.GlusterMgmt == glusterutils.MgmtGlusterd2 {
-		volOption = glusterutils.CountFOPHitsGD2
+	volOption := glusterconsts.CountFOPHitsGD1
+	var glusterConfig *conf.GConfig
+	if glusterConfig, err = conf.GConfigFromInterface(gluster); err != nil {
+		return err
+	}
+	if glusterConfig.GlusterMgmt == glusterconsts.MgmtGlusterd2 {
+		volOption = glusterconsts.CountFOPHitsGD2
 	}
 	var (
 		// supported aggregated operations are,

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -42,7 +42,7 @@ var (
 		Help:      "self heal count for volume in split brain",
 		LongHelp:  "",
 		Labels:    volumeHealLabels,
-	})
+	}, &volumeHealGaugeVecs)
 
 	volumeProfileInfoLabels = []MetricLabel{
 		clusterIDLabel,

--- a/gluster-exporter/metric_volume_counts.go
+++ b/gluster-exporter/metric_volume_counts.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/gluster/gluster-prometheus/pkg/glusterutils"
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -112,10 +113,10 @@ func volumeCounts(gluster glusterutils.GInterface) error {
 	for _, volume := range volumes {
 		up := 0
 		switch volume.State {
-		case glusterutils.VolumeStateStarted:
+		case glusterconsts.VolumeStateStarted:
 			up = 1
 			volStartCount++
-		case glusterutils.VolumeStateCreated:
+		case glusterconsts.VolumeStateCreated:
 			volCreatedCount++
 		default:
 			// Volume is stopped, nothing to do as the stopped count

--- a/pkg/glusterutils/cache.go
+++ b/pkg/glusterutils/cache.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"sync"
 	"time"
+
+	"github.com/gluster/gluster-prometheus/gluster-exporter/conf"
 )
 
 // GCache is a wrapper around 'GInterface' object
@@ -309,4 +311,12 @@ func (gc *GCache) VolumeProfileInfo(vol string) ([]ProfileInfo, error) {
 		err = errors.New("[CacheError] Unable to convert back to a valid return type")
 	}
 	return retVal, err
+}
+
+// GConfig implements GConfigInterface
+func (gc *GCache) GConfig() (gConf *conf.GConfig) {
+	// below comment is needed to avoid go-metalinter failures
+	// #nosec
+	gConf, _ = conf.GConfigFromInterface(gc.gd)
+	return
 }

--- a/pkg/glusterutils/common.go
+++ b/pkg/glusterutils/common.go
@@ -3,10 +3,11 @@ package glusterutils
 import (
 	"time"
 
+	"github.com/gluster/gluster-prometheus/gluster-exporter/conf"
 	"github.com/gluster/glusterd2/pkg/restclient"
 )
 
-func initRESTClient(config *Config) (*restclient.Client, error) {
+func initRESTClient(config *conf.GConfig) (*restclient.Client, error) {
 	client, err := restclient.New(
 		config.Glusterd2Endpoint,
 		config.Glusterd2User,
@@ -21,7 +22,7 @@ func initRESTClient(config *Config) (*restclient.Client, error) {
 	return client, nil
 }
 
-func setDefaultConfig(config *Config) {
+func setDefaultConfig(config *conf.GConfig) {
 	if config.Timeout == 0 {
 		config.Timeout = 30
 	}

--- a/pkg/glusterutils/enable_profile_gd1.go
+++ b/pkg/glusterutils/enable_profile_gd1.go
@@ -3,12 +3,13 @@ package glusterutils
 import (
 	"os/exec"
 
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 	log "github.com/sirupsen/logrus"
 )
 
 // EnableVolumeProfiling enables profiling for a volume
 func (g *GD1) EnableVolumeProfiling(volume Volume) error {
-	value, exists := volume.Options[CountFOPHitsGD1]
+	value, exists := volume.Options[glusterconsts.CountFOPHitsGD1]
 	if !exists {
 		// Enable profiling for the volumes as its not set
 		_, err := exec.Command(g.config.GlusterCmd, "volume", "profile", volume.Name, "start").Output()

--- a/pkg/glusterutils/enable_profile_gd2.go
+++ b/pkg/glusterutils/enable_profile_gd2.go
@@ -1,6 +1,7 @@
 package glusterutils
 
 import (
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 	"github.com/gluster/glusterd2/pkg/api"
 	log "github.com/sirupsen/logrus"
 )
@@ -12,15 +13,15 @@ func (g *GD2) EnableVolumeProfiling(volume Volume) error {
 		return err
 	}
 
-	value, exists := volume.Options[CountFOPHitsGD2]
+	value, exists := volume.Options[glusterconsts.CountFOPHitsGD2]
 	if !exists {
 		// Enable profiling for the volumes as its not set
 		err := client.VolumeSet(
 			volume.Name,
 			api.VolOptionReq{
 				Options: map[string]string{
-					CountFOPHitsGD2:       "on",
-					LatencyMeasurementGD2: "on",
+					glusterconsts.CountFOPHitsGD2:       "on",
+					glusterconsts.LatencyMeasurementGD2: "on",
 				},
 				VolOptionFlags: api.VolOptionFlags{
 					AllowAdvanced: true,

--- a/pkg/glusterutils/gd1.go
+++ b/pkg/glusterutils/gd1.go
@@ -2,6 +2,8 @@ package glusterutils
 
 import (
 	"encoding/xml"
+
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 )
 
 type healBricks struct {
@@ -165,10 +167,10 @@ func (t *gd1Transport) String() string {
 
 func getSubvolType(voltype string) string {
 	switch voltype {
-	case VolumeTypeDistReplicate:
-		return SubvolTypeReplicate
-	case VolumeTypeDistDisperse:
-		return SubvolTypeDisperse
+	case glusterconsts.VolumeTypeDistReplicate:
+		return glusterconsts.SubvolTypeReplicate
+	case glusterconsts.VolumeTypeDistDisperse:
+		return glusterconsts.SubvolTypeDisperse
 	default:
 		return voltype
 	}

--- a/pkg/glusterutils/glusterconsts/consts.go
+++ b/pkg/glusterutils/glusterconsts/consts.go
@@ -1,0 +1,52 @@
+package glusterconsts
+
+const (
+	// VolumeTypeDistReplicate represents Gluster distributed replicate volume
+	VolumeTypeDistReplicate = "Distributed Replicate"
+	// VolumeTypeDistDisperse represents Gluster distributed disperse volume
+	VolumeTypeDistDisperse = "Distributed Disperse"
+	// VolumeTypeReplicate represents Gluster replicate volume
+	VolumeTypeReplicate = "Replicate"
+	// VolumeTypeDisperse represents Gluster disperse volume
+	VolumeTypeDisperse = "Disperse"
+	// VolumeTypeDistribute represents Gluster distribute volume
+	VolumeTypeDistribute = "Distribute"
+	// SubvolTypeDistribute represents Gluster distribute sub volume
+	SubvolTypeDistribute = VolumeTypeDistribute
+	// SubvolTypeReplicate represents Gluster replicate sub volume
+	SubvolTypeReplicate = VolumeTypeReplicate
+	// SubvolTypeDisperse represents Gluster disperse sub volume
+	SubvolTypeDisperse = VolumeTypeDisperse
+	// BrickTypeDefault represents default brick type
+	BrickTypeDefault = "Brick"
+	// BrickTypeArbiter represents arbiter brick type
+	BrickTypeArbiter = "Arbiter"
+
+	// MgmtGlusterd represents glusterd
+	MgmtGlusterd = "glusterd"
+	// MgmtGlusterd2 represents glusterd
+	MgmtGlusterd2 = "glusterd2"
+	// EnvGD2Endpoints environment variable
+	EnvGD2Endpoints = "GD2_ENDPOINTS"
+	// EnvGlusterClusterID environment variable for cluster id
+	EnvGlusterClusterID = "GLUSTER_CLUSTER_ID"
+
+	// VolumeStateCreated represents Volume Created state
+	VolumeStateCreated = "Created"
+	// VolumeStateStarted represents Volume started state
+	VolumeStateStarted = "Started"
+	// VolumeStateStopped represents Volume stopped state
+	VolumeStateStopped = "Stopped"
+
+	// CountFOPHitsGD1 represents volume option name for fop hits counts
+	CountFOPHitsGD1 = "diagnostics.count-fop-hits"
+	// LatencyMeasurementGD1 represents volume option for latency measurement
+	LatencyMeasurementGD1 = "diagnostics.latency-measurement"
+	// CountFOPHitsGD2 represents volume option name for fop hits counts
+	CountFOPHitsGD2 = "debug/io-stats.count-fop-hits"
+	// LatencyMeasurementGD2 represents volume option for latency measurement
+	LatencyMeasurementGD2 = "debug/io-stats.latency-measurement"
+
+	// DefaultGlusterClusterID provides the default clusnter ID
+	DefaultGlusterClusterID = "default"
+)

--- a/pkg/glusterutils/types.go
+++ b/pkg/glusterutils/types.go
@@ -1,61 +1,8 @@
 package glusterutils
 
-const (
-	// VolumeTypeDistReplicate represents Gluster distributed replicate volume
-	VolumeTypeDistReplicate = "Distributed Replicate"
-	// VolumeTypeDistDisperse represents Gluster distributed disperse volume
-	VolumeTypeDistDisperse = "Distributed Disperse"
-	// VolumeTypeReplicate represents Gluster replicate volume
-	VolumeTypeReplicate = "Replicate"
-	// VolumeTypeDisperse represents Gluster disperse volume
-	VolumeTypeDisperse = "Disperse"
-	// VolumeTypeDistribute represents Gluster distribute volume
-	VolumeTypeDistribute = "Distribute"
-	// SubvolTypeDistribute represents Gluster distribute sub volume
-	SubvolTypeDistribute = VolumeTypeDistribute
-	// SubvolTypeReplicate represents Gluster replicate sub volume
-	SubvolTypeReplicate = VolumeTypeReplicate
-	// SubvolTypeDisperse represents Gluster disperse sub volume
-	SubvolTypeDisperse = VolumeTypeDisperse
-	// BrickTypeDefault represents default brick type
-	BrickTypeDefault = "Brick"
-	// BrickTypeArbiter represents arbiter brick type
-	BrickTypeArbiter = "Arbiter"
-
-	// MgmtGlusterd represents glusterd
-	MgmtGlusterd = "glusterd"
-	// MgmtGlusterd2 represents glusterd
-	MgmtGlusterd2 = "glusterd2"
-
-	// VolumeStateCreated represents Volume Created state
-	VolumeStateCreated = "Created"
-	// VolumeStateStarted represents Volume started state
-	VolumeStateStarted = "Started"
-	// VolumeStateStopped represents Volume stopped state
-	VolumeStateStopped = "Stopped"
-
-	// CountFOPHitsGD1 represents volume option name for fop hits counts
-	CountFOPHitsGD1 = "diagnostics.count-fop-hits"
-	// LatencyMeasurementGD1 represents volume option for latency measurement
-	LatencyMeasurementGD1 = "diagnostics.latency-measurement"
-	// CountFOPHitsGD2 represents volume option name for fop hits counts
-	CountFOPHitsGD2 = "debug/io-stats.count-fop-hits"
-	// LatencyMeasurementGD2 represents volume option for latency measurement
-	LatencyMeasurementGD2 = "debug/io-stats.latency-measurement"
+import (
+	"github.com/gluster/gluster-prometheus/gluster-exporter/conf"
 )
-
-// Config represents Glusterd1/Glusterd2 configurations
-type Config struct {
-	GlusterMgmt       string
-	Glusterd2Endpoint string
-	GlusterCmd        string
-	GlusterdWorkdir   string
-	Glusterd2User     string
-	Glusterd2Secret   string
-	Glusterd2Cacert   string
-	Glusterd2Insecure bool
-	Timeout           int64
-}
 
 // Peer represents a Gluster Peer
 type Peer struct {
@@ -169,10 +116,10 @@ type ProfileInfo struct {
 
 // GD1 enables users to interact with gd1 version
 type GD1 struct {
-	config *Config
+	config *conf.GConfig
 }
 
 // GD2 is struct to interact with Glusterd2 using REST API
 type GD2 struct {
-	config *Config
+	config *conf.GConfig
 }

--- a/pkg/glusterutils/volinfo_gd1.go
+++ b/pkg/glusterutils/volinfo_gd1.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 )
 
 // VolumeInfo returns gluster vol info (glusterd)
@@ -52,9 +54,9 @@ func (g *GD1) VolumeInfo() ([]Volume, error) {
 			outvol.SubVolumes[sidx].DisperseRedundancyCount = vol.DisperseRedundancyCount
 			outvol.SubVolumes[sidx].Name = fmt.Sprintf("%s-%s-%d", vol.Name, strings.ToLower(subvolType), sidx)
 			for bidx := 0; bidx < subvolBricksCount; bidx++ {
-				brickType := BrickTypeDefault
+				brickType := glusterconsts.BrickTypeDefault
 				if vol.Bricks[sidx+bidx].IsArbiter == 1 {
-					brickType = BrickTypeArbiter
+					brickType = glusterconsts.BrickTypeArbiter
 				}
 				brickParts := strings.Split(vol.Bricks[sidx+bidx].Name, ":")
 				brick := Brick{


### PR DESCRIPTION
There are TWO kinds of configs here,

1. ```conf.Config```, exporter TOML configuration
2. ```glusterutils.Config```, gluster configuration

**Config creation**

* Creating ```conf.Config```
Following function will create it,
```conf.LoadConfig(toml_file_path)```

* Creating ```glusterutils.Config```
This config can be created from ```conf.Config``` object,
```glusterutils.GConfigFromExporterConfig(*conf.Config)```

**Accessing the configuration**

* Getting ```conf.Config``` object
We retrieve the exporter config through ```glusterutils.Config``` object
```gConfig.ParentConfig()``` returns ```conf.Config```

* Getting ```glusterutils.Config``` object
This config is got from GD1 or GD2 objects,
```GD1_or_GD2_object.Config()```

* But as we are passing it (GD1/GD2 objects) as ```GInterface``` objects,
we have to use the following utility function,
```glusterutils.GConfigFromInterface(GInterface_Object)```

Fixes: issue https://github.com/gluster/gluster-prometheus/issues/129

Signed-off-by: Arun Kumar Mohan <arun.iiird@gmail.com>