### PR TITLE
Forget old volumes

### DIFF
--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -136,13 +136,15 @@ var (
 		},
 	}
 
+	brickGaugeVecs []*prometheus.GaugeVec
+
 	glusterBrickCapacityUsed = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_capacity_used_bytes",
 		Help:      "Used capacity of gluster bricks in bytes",
 		LongHelp:  "",
 		Labels:    brickLabels,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickCapacityFree = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -150,7 +152,7 @@ var (
 		Help:      "Free capacity of gluster bricks in bytes",
 		LongHelp:  "",
 		Labels:    brickLabels,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickCapacityTotal = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -158,7 +160,7 @@ var (
 		Help:      "Total capacity of gluster bricks in bytes",
 		LongHelp:  "",
 		Labels:    brickLabels,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickInodesTotal = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -166,7 +168,7 @@ var (
 		Help:      "Total no of inodes of gluster brick disk",
 		LongHelp:  "",
 		Labels:    brickLabels,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickInodesFree = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -174,7 +176,7 @@ var (
 		Help:      "Free no of inodes of gluster brick disk",
 		LongHelp:  "",
 		Labels:    brickLabels,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickInodesUsed = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -182,7 +184,7 @@ var (
 		Help:      "Used no of inodes of gluster brick disk",
 		LongHelp:  "",
 		Labels:    brickLabels,
-	})
+	}, &brickGaugeVecs)
 
 	glusterSubvolCapacityUsed = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -190,7 +192,7 @@ var (
 		Help:      "Effective used capacity of gluster subvolume in bytes",
 		LongHelp:  "",
 		Labels:    subvolLabels,
-	})
+	}, &brickGaugeVecs)
 
 	glusterSubvolCapacityTotal = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -198,7 +200,7 @@ var (
 		Help:      "Effective total capacity of gluster subvolume in bytes",
 		LongHelp:  "",
 		Labels:    subvolLabels,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickLVSize = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -206,7 +208,7 @@ var (
 		Help:      "Bricks LV size Bytes",
 		LongHelp:  "",
 		Labels:    lvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickLVPercent = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -214,7 +216,7 @@ var (
 		Help:      "Bricks LV usage percent",
 		LongHelp:  "",
 		Labels:    lvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickLVMetadataSize = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -222,7 +224,7 @@ var (
 		Help:      "Bricks LV metadata size Bytes",
 		LongHelp:  "",
 		Labels:    lvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterBrickLVMetadataPercent = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -230,7 +232,7 @@ var (
 		Help:      "Bricks LV metadata usage percent",
 		LongHelp:  "",
 		Labels:    lvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterVGExtentTotal = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -238,7 +240,7 @@ var (
 		Help:      "VG extent total count ",
 		LongHelp:  "",
 		Labels:    lvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterVGExtentAlloc = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -246,7 +248,7 @@ var (
 		Help:      "VG extent allocated count ",
 		LongHelp:  "",
 		Labels:    lvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterThinPoolDataTotal = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -254,7 +256,7 @@ var (
 		Help:      "Thin pool size Bytes",
 		LongHelp:  "",
 		Labels:    thinLvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterThinPoolDataUsed = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -262,7 +264,7 @@ var (
 		Help:      "Thin pool data used Bytes",
 		LongHelp:  "",
 		Labels:    thinLvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterThinPoolMetadataTotal = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -270,7 +272,7 @@ var (
 		Help:      "Thin pool metadata size Bytes",
 		LongHelp:  "",
 		Labels:    thinLvmLbls,
-	})
+	}, &brickGaugeVecs)
 
 	glusterThinPoolMetadataUsed = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -278,7 +280,9 @@ var (
 		Help:      "Thin pool metadata used Bytes",
 		LongHelp:  "",
 		Labels:    thinLvmLbls,
-	})
+	}, &brickGaugeVecs)
+
+	brickStatusGaugeVecs []*prometheus.GaugeVec
 
 	glusterBrickUp = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -286,7 +290,7 @@ var (
 		Help:      "Brick up (1-up, 0-down)",
 		LongHelp:  "",
 		Labels:    brickStatusLbls,
-	})
+	}, &brickStatusGaugeVecs)
 )
 
 func getGlusterBrickLabels(brick glusterutils.Brick, subvol string) prometheus.Labels {
@@ -576,7 +580,13 @@ func lvmUsage(path string) (stats []LVMStat, thinPoolStats []ThinPoolStat, err e
 }
 
 func brickUtilization(gluster glusterutils.GInterface) error {
+	// Reset all vecs to not export stale information
+	for _, gaugeVec := range brickGaugeVecs {
+		gaugeVec.Reset()
+	}
+
 	volumes, err := gluster.VolumeInfo()
+
 	if err != nil {
 		// Return without exporting metric in this cycle
 		return err
@@ -693,11 +703,18 @@ func getBrickStatusLabels(vol string, host string, brickPath string, peerID stri
 }
 
 func brickStatus(gluster glusterutils.GInterface) error {
+	// Reset all vecs to not export stale information
+	for _, gaugeVec := range brickStatusGaugeVecs {
+		gaugeVec.Reset()
+	}
+
 	isLeader, err := gluster.IsLeader()
+
 	if err != nil {
 		log.WithError(err).Error("Unable to find if the current node is leader")
 		return err
 	}
+
 	if !isLeader {
 		return nil
 	}
@@ -706,6 +723,7 @@ func brickStatus(gluster glusterutils.GInterface) error {
 	if err != nil {
 		return err
 	}
+
 	for _, volume := range volumes {
 		// If volume is down, the bricks should be marked down
 		var brickStatus []glusterutils.BrickStatus

--- a/gluster-exporter/metric_peer_counts.go
+++ b/gluster-exporter/metric_peer_counts.go
@@ -127,38 +127,46 @@ var (
 		},
 	}
 
+	peerCountsGaugeVecs []*prometheus.GaugeVec
+
 	glusterPVCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "pv_count",
 		Help:      "No: of Physical Volumes",
 		LongHelp:  "",
 		Labels:    gnrlMetricLabels,
-	})
+	}, &peerCountsGaugeVecs)
 	glusterLVCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "lv_count",
 		Help:      "No: of Logical Volumes in a Volume Group",
 		LongHelp:  "",
 		Labels:    withVgMetricLabels,
-	})
+	}, &peerCountsGaugeVecs)
 	glusterVGCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "vg_count",
 		Help:      "No: of Volume Groups",
 		LongHelp:  "",
 		Labels:    gnrlMetricLabels,
-	})
+	}, &peerCountsGaugeVecs)
 	glusterTPCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "thinpool_count",
 		Help:      "No: of thinpools in a Volume Group",
 		LongHelp:  "",
 		Labels:    withVgMetricLabels,
-	})
+	}, &peerCountsGaugeVecs)
 )
 
 func peerCounts(gluster glusterutils.GInterface) (err error) {
+	// Reset all vecs to not export stale information
+	for _, gaugeVec := range peerCountsGaugeVecs {
+		gaugeVec.Reset()
+	}
+
 	var peerID string
+
 	// 'gluster' is initialized inside 'main' function,
 	// so it is better to check whether it is available or not
 	if gluster != nil {

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -25,13 +25,15 @@ var (
 		},
 	}
 
+	volumeHealGaugeVecs []*prometheus.GaugeVec
+
 	glusterVolumeHealCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_heal_count",
 		Help:      "self heal count for volume",
 		LongHelp:  "",
 		Labels:    volumeHealLabels,
-	})
+	}, &volumeHealGaugeVecs)
 
 	volumeProfileInfoLabels = []MetricLabel{
 		{
@@ -44,13 +46,15 @@ var (
 		},
 	}
 
+	volumeProfileGaugeVecs []*prometheus.GaugeVec
+
 	glusterVolumeProfileTotalReads = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_total_reads",
 		Help:      "Total no of reads",
 		LongHelp:  "",
 		Labels:    volumeProfileInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileTotalWrites = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -58,7 +62,7 @@ var (
 		Help:      "Total no of writes",
 		LongHelp:  "",
 		Labels:    volumeProfileInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileDuration = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -66,7 +70,7 @@ var (
 		Help:      "Duration",
 		LongHelp:  "",
 		Labels:    volumeProfileInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileTotalReadsInt = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -74,7 +78,7 @@ var (
 		Help:      "Total no of reads for interval stats",
 		LongHelp:  "",
 		Labels:    volumeProfileInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileTotalWritesInt = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -82,7 +86,7 @@ var (
 		Help:      "Total no of writes for interval stats",
 		LongHelp:  "",
 		Labels:    volumeProfileInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileDurationInt = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -90,7 +94,7 @@ var (
 		Help:      "Duration for interval stats",
 		LongHelp:  "",
 		Labels:    volumeProfileInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	volumeProfileFopInfoLabels = []MetricLabel{
 		{
@@ -117,7 +121,7 @@ var (
 		Help:      "Cumulative FOP hits",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopAvgLatency = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -125,7 +129,7 @@ var (
 		Help:      "Cumulative FOP avergae latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopMinLatency = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -133,7 +137,7 @@ var (
 		Help:      "Cumulative FOP min latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopMaxLatency = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -141,7 +145,7 @@ var (
 		Help:      "Cumulative FOP max latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopHitsInt = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -149,7 +153,7 @@ var (
 		Help:      "Interval based FOP hits",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopAvgLatencyInt = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -157,7 +161,7 @@ var (
 		Help:      "Interval based FOP average latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopMinLatencyInt = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -165,7 +169,7 @@ var (
 		Help:      "Interval based FOP min latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopMaxLatencyInt = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -173,7 +177,7 @@ var (
 		Help:      "Interval based FOP max latency",
 		LongHelp:  "",
 		Labels:    volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopTotalHitsAggregatedOps = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -182,7 +186,7 @@ var (
 			" like READ_WRIET_OPS, LOCK_OPS, INODE_OPS etc",
 		LongHelp: "",
 		Labels:   volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 
 	glusterVolumeProfileFopTotalHitsAggregatedOpsInt = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -191,7 +195,7 @@ var (
 			" like READ_WRIET_OPS, LOCK_OPS, INODE_OPS etc",
 		LongHelp: "",
 		Labels:   volumeProfileFopInfoLabels,
-	})
+	}, &volumeProfileGaugeVecs)
 )
 
 // opType represents aggregated operations like
@@ -295,6 +299,11 @@ func getVolumeHealLabels(volname string, host string, brick string) prometheus.L
 func healCounts(gluster glusterutils.GInterface) error {
 	isLeader, err := gluster.IsLeader()
 
+	// Reset all vecs to not export stale information
+	for _, gaugeVec := range volumeHealGaugeVecs {
+		gaugeVec.Reset()
+	}
+
 	if err != nil {
 		// Unable to find out if the current node is leader
 		// Cannot register volume metrics at this node
@@ -356,7 +365,13 @@ func getBrickHost(vol glusterutils.Volume, brickname string) string {
 }
 
 func profileInfo(gluster glusterutils.GInterface) error {
+	// Reset all vecs to not export stale information
+	for _, gaugeVec := range volumeProfileGaugeVecs {
+		gaugeVec.Reset()
+	}
+
 	isLeader, err := gluster.IsLeader()
+
 	if err != nil {
 		log.WithError(err).Error("Unable to find if the current node is leader")
 		return err

--- a/gluster-exporter/metric_volume_counts.go
+++ b/gluster-exporter/metric_volume_counts.go
@@ -15,13 +15,15 @@ var (
 		},
 	}
 
+	volumeCountGaugeVecs []*prometheus.GaugeVec
+
 	glusterVolumeTotalCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_total_count",
 		Help:      "Total no of volumes",
 		LongHelp:  "",
 		Labels:    []MetricLabel{},
-	})
+	}, &volumeCountGaugeVecs)
 
 	glusterVolumeCreatedCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -29,7 +31,7 @@ var (
 		Help:      "Freshly created no of volumes",
 		LongHelp:  "",
 		Labels:    []MetricLabel{},
-	})
+	}, &volumeCountGaugeVecs)
 
 	glusterVolumeStartedCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -37,7 +39,7 @@ var (
 		Help:      "Total no of started volumes",
 		LongHelp:  "",
 		Labels:    []MetricLabel{},
-	})
+	}, &volumeCountGaugeVecs)
 
 	glusterVolumeBrickCount = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -45,7 +47,7 @@ var (
 		Help:      "Total no of bricks in volume",
 		LongHelp:  "",
 		Labels:    volumeLabels,
-	})
+	}, &volumeCountGaugeVecs)
 
 	glusterVolumeSnapshotBrickCountTotal = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -53,7 +55,7 @@ var (
 		Help:      "Total count of snapshots bricks for volume",
 		LongHelp:  "",
 		Labels:    volumeLabels,
-	})
+	}, &volumeCountGaugeVecs)
 
 	glusterVolumeSnapshotBrickCountActive = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -61,7 +63,7 @@ var (
 		Help:      "Total active count of snapshots bricks for volume",
 		LongHelp:  "",
 		Labels:    volumeLabels,
-	})
+	}, &volumeCountGaugeVecs)
 
 	glusterVolumeUp = newPrometheusGaugeVec(Metric{
 		Namespace: "gluster",
@@ -69,7 +71,7 @@ var (
 		Help:      "Volume is started or not (1-started, 0-not started)",
 		LongHelp:  "",
 		Labels:    volumeLabels,
-	})
+	}, &volumeCountGaugeVecs)
 )
 
 func getVolumeLabels(volname string) prometheus.Labels {
@@ -79,7 +81,13 @@ func getVolumeLabels(volname string) prometheus.Labels {
 }
 
 func volumeCounts(gluster glusterutils.GInterface) error {
+	// Reset all vecs to not export stale information
+	for _, gaugeVec := range volumeCountGaugeVecs {
+		gaugeVec.Reset()
+	}
+
 	isLeader, err := gluster.IsLeader()
+
 	if err != nil {
 		log.WithError(err).Error("Unable to find if the current node is leader")
 		return err

--- a/gluster-exporter/metrics.go
+++ b/gluster-exporter/metrics.go
@@ -32,7 +32,9 @@ func (m *Metric) LabelNames() []string {
 // newPrometheusGaugeVec is wrapper around prometheus.NewGaugeVec. Additionally
 // it registers with global map which can be used for documentation,
 // listing supported metrics via CLI etc.
-func newPrometheusGaugeVec(m Metric) *prometheus.GaugeVec {
+// 'gaugeVecArrPtr' helps to collect all the 'GaugeVec' pertaining to a metric
+// group.  Ignored if 'nil'
+func newPrometheusGaugeVec(m Metric, gaugeVecArrPtr *[]*prometheus.GaugeVec) *prometheus.GaugeVec {
 	gaugeVec := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: m.Namespace,
@@ -44,6 +46,10 @@ func newPrometheusGaugeVec(m Metric) *prometheus.GaugeVec {
 
 	// Register the metric with Prometheus
 	prometheus.MustRegister(gaugeVec)
+
+	if gaugeVecArrPtr != nil {
+		*gaugeVecArrPtr = append(*gaugeVecArrPtr, gaugeVec)
+	}
 
 	// Add the metric to the global queue
 	metrics = append(metrics, m)


### PR DESCRIPTION
Ref #89 

Using const metrics ensures values for old labels (such as for deleted volumes) are not reported again