### PR TITLE
Implement support for --remote-host to connect to GD1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,7 @@ collectors related configurations.
 gluster-mgmt = "glusterd"
 glusterd-dir = "/var/lib/glusterd"
 gluster-binary-path = "gluster"
+gd1-remote-host = "localhost"
 gd2-rest-endpoint = "http://127.0.0.1:24007"
 port = 8080
 metrics-path = "/metrics"

--- a/gluster-exporter/conf/conf.go
+++ b/gluster-exporter/conf/conf.go
@@ -15,6 +15,7 @@ type GConfig struct {
 	GlusterMgmt       string `toml:"gluster-mgmt"`
 	Glusterd2Endpoint string `toml:"gd2-rest-endpoint"`
 	GlusterCmd        string `toml:"gluster-binary-path"`
+	GlusterRemoteHost string `toml:"gd1-remote-host"`
 	GlusterdWorkdir   string `toml:"glusterd-dir"`
 	GlusterClusterID  string `toml:"gluster-cluster-id"`
 	Glusterd2User     string

--- a/pkg/glusterutils/brick_status_gd1.go
+++ b/pkg/glusterutils/brick_status_gd1.go
@@ -2,13 +2,12 @@ package glusterutils
 
 import (
 	"encoding/xml"
-	"os/exec"
 )
 
 // VolumeBrickStatus gets brick status info from glusterd2 using rest api
 func (g GD1) VolumeBrickStatus(vol string) ([]BrickStatus, error) {
-	// Run gluster volume status {vol} --xml
-	out, err := exec.Command(g.config.GlusterCmd, "volume", "status", vol, "--xml").Output()
+	// Run gluster volume status {vol}
+	out, err := g.execGluster("volume", "status", vol)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/glusterutils/common.go
+++ b/pkg/glusterutils/common.go
@@ -32,6 +32,9 @@ func setDefaultConfig(config *conf.GConfig) {
 	if config.GlusterCmd == "" {
 		config.GlusterCmd = "gluster"
 	}
+	if config.GlusterRemoteHost == "" {
+		config.GlusterRemoteHost = "localhost"
+	}
 	if config.Glusterd2Endpoint == "" {
 		config.Glusterd2Endpoint = "http://localhost:24007"
 	}

--- a/pkg/glusterutils/enable_profile_gd1.go
+++ b/pkg/glusterutils/enable_profile_gd1.go
@@ -1,8 +1,6 @@
 package glusterutils
 
 import (
-	"os/exec"
-
 	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
 	log "github.com/sirupsen/logrus"
 )
@@ -12,7 +10,7 @@ func (g *GD1) EnableVolumeProfiling(volume Volume) error {
 	value, exists := volume.Options[glusterconsts.CountFOPHitsGD1]
 	if !exists {
 		// Enable profiling for the volumes as its not set
-		_, err := exec.Command(g.config.GlusterCmd, "volume", "profile", volume.Name, "start").Output()
+		_, err := g.execGluster("volume", "profile", volume.Name, "start")
 		if err != nil {
 			return err
 		}

--- a/pkg/glusterutils/gd1.go
+++ b/pkg/glusterutils/gd1.go
@@ -190,9 +190,11 @@ func getSubvolBricksCount(replicaCount int, disperseCount int) int {
 	return 1
 }
 
-// execGluster runs `gluster` with --xml and the args provided
+// execGluster runs `gluster` with --xml --remote-host=<...> and the args provided
 func (g *GD1) execGluster(args ...string) ([]byte, error) {
 	// always request output in XML format
 	args = append(args, "--xml")
+	// grab remote host from config
+	args = append(args, fmt.Sprintf("--remote-host=%s", g.config.GlusterRemoteHost))
 	return exec.Command(g.config.GlusterCmd, args...).Output()
 }

--- a/pkg/glusterutils/gd1.go
+++ b/pkg/glusterutils/gd1.go
@@ -4,6 +4,9 @@ import (
 	"encoding/xml"
 
 	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
+
+	"fmt"
+	"os/exec"
 )
 
 type healBricks struct {
@@ -185,4 +188,11 @@ func getSubvolBricksCount(replicaCount int, disperseCount int) int {
 		return disperseCount
 	}
 	return 1
+}
+
+// execGluster runs `gluster` with --xml and the args provided
+func (g *GD1) execGluster(args ...string) ([]byte, error) {
+	// always request output in XML format
+	args = append(args, "--xml")
+	return exec.Command(g.config.GlusterCmd, args...).Output()
 }

--- a/pkg/glusterutils/healinfo_gd1.go
+++ b/pkg/glusterutils/healinfo_gd1.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 )
 
-func getHealDetails(cmd string) ([]HealEntry, error) {
-	out, err := ExecuteCmd(cmd)
+func (g *GD1) getHealDetails(cmd string) ([]HealEntry, error) {
+	args := strings.Fields(cmd)
+	out, err := g.execGluster(args...)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +40,8 @@ func getHealDetails(cmd string) ([]HealEntry, error) {
 // HealInfo gets gluster vol heal info (GD1)
 func (g GD1) HealInfo(vol string) ([]HealEntry, error) {
 	// Get the overall heal count
-	cmd := fmt.Sprintf("%s vol heal %s info --xml", g.config.GlusterCmd, vol)
-	heals, err := getHealDetails(cmd)
+	cmd := fmt.Sprintf("vol heal %s info", vol)
+	heals, err := g.getHealDetails(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +51,8 @@ func (g GD1) HealInfo(vol string) ([]HealEntry, error) {
 
 // SplitBrainHealInfo gets gluster vol heal info (GD1)
 func (g GD1) SplitBrainHealInfo(vol string) ([]HealEntry, error) {
-	cmd := fmt.Sprintf("%s vol heal %s info split-brain --xml", g.config.GlusterCmd, vol)
-	splitBrainHeals, err := getHealDetails(cmd)
+	cmd := fmt.Sprintf("vol heal %s info split-brain", vol)
+	splitBrainHeals, err := g.getHealDetails(cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/glusterutils/peers_gd1.go
+++ b/pkg/glusterutils/peers_gd1.go
@@ -2,7 +2,6 @@ package glusterutils
 
 import (
 	"encoding/xml"
-	"os/exec"
 )
 
 type peerGlusterd1 struct {
@@ -22,7 +21,7 @@ type peersGlusterd1 struct {
 func (g *GD1) Peers() ([]Peer, error) {
 	var gd1Peers peersGlusterd1
 	var peersgd1 []Peer
-	out, err := exec.Command(g.config.GlusterCmd, "pool", "list", "--xml").Output()
+	out, err := g.execGluster("pool", "list")
 	if err != nil {
 		return peersgd1, err
 	}

--- a/pkg/glusterutils/profileinfo_gd1.go
+++ b/pkg/glusterutils/profileinfo_gd1.go
@@ -2,13 +2,12 @@ package glusterutils
 
 import (
 	"encoding/xml"
-	"os/exec"
 )
 
 // VolumeProfileInfo returns profile info details for the volume
 func (g *GD1) VolumeProfileInfo(vol string) ([]ProfileInfo, error) {
-	// Run Gluster volume profile <volname> info --xml
-	out, err := exec.Command(g.config.GlusterCmd, "volume", "profile", vol, "info", "--xml").Output()
+	// Run Gluster volume profile <volname> info
+	out, err := g.execGluster("volume", "profile", vol, "info")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/glusterutils/snapshots_gd1.go
+++ b/pkg/glusterutils/snapshots_gd1.go
@@ -2,13 +2,12 @@ package glusterutils
 
 import (
 	"encoding/xml"
-	"os/exec"
 )
 
 // Snapshots returns snaphosts list for the cluster
 func (g *GD1) Snapshots() ([]Snapshot, error) {
-	// Run Gluster snapshot list --xml
-	out, err := exec.Command(g.config.GlusterCmd, "snapshot", "info", "--xml").Output()
+	// Run Gluster snapshot list
+	out, err := g.execGluster("snapshot", "info")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/glusterutils/volinfo_gd1.go
+++ b/pkg/glusterutils/volinfo_gd1.go
@@ -3,7 +3,6 @@ package glusterutils
 import (
 	"encoding/xml"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/gluster/gluster-prometheus/pkg/glusterutils/glusterconsts"
@@ -11,8 +10,8 @@ import (
 
 // VolumeInfo returns gluster vol info (glusterd)
 func (g *GD1) VolumeInfo() ([]Volume, error) {
-	// Run Gluster volume info --xml
-	out, err := exec.Command(g.config.GlusterCmd, "volume", "info", "--xml").Output()
+	// Run Gluster volume info
+	out, err := g.execGluster("volume", "info")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request makes two distinct changes:

1. Refactor calls to `gluster` in the GD1 backend, to a method on `GD1`. This method specifies parameters which are passed to each call, such as `--xml` and eliminates the need to write a custom, but repetitive `exec.Command()` in each method that queries GD1 for some information.

2. Building on the refactored method to execute `gluster`, the second commit implements all the bits which are required to make `gluster` connect to a remote host. The config variable `gd1-remote-host` allows the user to specify the hostname or IP address of the GD1 instance to which the exporter should connect. If the variable is missing from the config file, the value of GConfig.GlusterRemoteHost` is set to `localhost`.

If you would prefer to have a pull request for each change we're happy to accommodate.