### PR TITLE
Fix gometalinter issues

### DIFF
--- a/gluster-exporter/conf/conf.go
+++ b/gluster-exporter/conf/conf.go
@@ -101,5 +101,5 @@ func GConfigFromInterface(iFace interface{}) (*GConfig, error) {
 	if gConfig, ok := iFace.(GConfigInterface); ok {
 		return gConfig.GConfig(), nil
 	}
-	return nil, errors.New("Provided interface don't implement 'GConfigInterface'")
+	return nil, errors.New("provided interface don't implement 'GConfigInterface'")
 }

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -249,9 +249,9 @@ func newOperationType(commonOpName string, supportedOpLabels []string) (opType, 
 	commonOpName = strings.TrimSpace(commonOpName)
 	var opT = opType{opName: commonOpName}
 	if len(supportedOpLabels) == 0 {
-		return opT, errors.New("Supported operation labels should not be empty")
+		return opT, errors.New("supported operation labels should not be empty")
 	} else if commonOpName == "" {
-		return opT, errors.New("Empty common operation name is not allowed")
+		return opT, errors.New("empty common operation name is not allowed")
 	}
 	opT.opsSupported = make(map[string]struct{})
 	var emtS struct{}

--- a/scripts/install-reqs.sh
+++ b/scripts/install-reqs.sh
@@ -54,7 +54,7 @@ install_dep() {
 }
 
 install_gometalinter() {
-  LINTER_VER="2.0.5"
+  LINTER_VER="3.0.0"
   LINTER_TARBALL="gometalinter-${LINTER_VER}-linux-amd64.tar.gz"
   LINTER_URL="https://github.com/alecthomas/gometalinter/releases/download/v${LINTER_VER}/${LINTER_TARBALL}"
 


### PR DESCRIPTION
New errors catched after upgrading to gometalinter v3.0.0

gluster-exporter/conf/conf.go:104:24:warning: error strings should not
be capitalized (ST1005) (staticcheck)
gluster-exporter/metric_volume.go:252:25:warning: error strings should
not be capitalized (ST1005) (staticcheck)
gluster-exporter/metric_volume.go:254:25:warning: error strings should
not be capitalized (ST1005) (staticcheck)

Signed-off-by: Aravinda VK <avishwan@redhat.com>