### PR TITLE
Implement metrics which provide information about peers

### DIFF
--- a/gluster-exporter/metric_peers.go
+++ b/gluster-exporter/metric_peers.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	peerCountMetricLabels = []MetricLabel{
+		{
+			Name: "instance",
+			Help: "Hostname of the gluster-prometheus instance providing this metric",
+		},
+	}
+	peerSCMetricLabels = []MetricLabel{
+		{
+			Name: "instance",
+			Help: "Hostname of the gluster-prometheus instance providing this metric",
+		},
+		{
+			Name: "hostname",
+			Help: "Hostname of the peer for which data is collected",
+		},
+		{
+			Name: "uuid",
+			Help: "Uuid of the peer for which data is collected",
+		},
+	}
+
+	peerGaugeVecs []*prometheus.GaugeVec
+
+	glusterPeerCount = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "peer_count",
+		Help:      "Number of peers in cluster",
+		Labels:    peerCountMetricLabels,
+	}, &peerGaugeVecs)
+
+	glusterPeerStatus = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "peer_status",
+		Help:      "Peer status info",
+		Labels:    peerSCMetricLabels,
+	}, &peerGaugeVecs)
+
+	glusterPeerConnected = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "peer_connected",
+		Help:      "Peer connection status",
+		Labels:    peerSCMetricLabels,
+	}, &peerGaugeVecs)
+)
+
+func peerInfo(gluster glusterutils.GInterface) (err error) {
+	// Reset all vecs to not export stale information
+	for _, gaugeVec := range peerGaugeVecs {
+		gaugeVec.Reset()
+	}
+
+	var peerID string
+
+	if gluster != nil {
+		if peerID, err = gluster.LocalPeerID(); err != nil {
+			return
+		}
+	}
+
+	peers, err := gluster.Peers()
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{"peer": peerID}).Debug("[Gluster Peers] Error:", err)
+		return err
+	}
+
+	fqdn := "n/a"
+	for _, peer := range peers {
+		if peer.ID == peerID {
+			// TODO: figure out which value of PeerAddresses may
+			// be hostname -- or resolve ip ourselves
+			fqdn = peer.PeerAddresses[0]
+		}
+	}
+
+	peerCountLabels := prometheus.Labels{
+		"instance": fqdn,
+	}
+
+	glusterPeerCount.With(peerCountLabels).Set(float64(len(peers)))
+
+	var connected int
+	for _, peer := range peers {
+		peerSCLabels := prometheus.Labels{
+			"instance": fqdn,
+			"hostname": peer.PeerAddresses[0],
+			"uuid":     peer.ID,
+		}
+		if peer.Online {
+			connected = 1
+		} else {
+			connected = 0
+		}
+		// Only update glusterPeerStatus when we retrieved a
+		// non-negative peer state, i.e. we're running with the GD1
+		// backend.
+		if peer.Gd1State > -1 {
+			glusterPeerStatus.With(peerSCLabels).Set(float64(peer.Gd1State))
+		}
+		glusterPeerConnected.With(peerSCLabels).Set(float64(connected))
+	}
+
+	return
+}
+
+func init() {
+	registerMetric("gluster_peer_info", peerInfo)
+}

--- a/pkg/glusterutils/peers_gd1.go
+++ b/pkg/glusterutils/peers_gd1.go
@@ -42,6 +42,7 @@ func (g *GD1) Peers() ([]Peer, error) {
 			ID:            peergd1.PeerID,
 			PeerAddresses: peergd1.Hostname,
 			Online:        online,
+			Gd1State:      peergd1.State,
 		}
 	}
 

--- a/pkg/glusterutils/peers_gd2.go
+++ b/pkg/glusterutils/peers_gd2.go
@@ -27,6 +27,7 @@ func (g *GD2) Peers() ([]Peer, error) {
 			ID:            peergd2.ID.String(),
 			PeerAddresses: peergd2.PeerAddresses,
 			Online:        peergd2.Online,
+			Gd1State:      -1, // Gd1State is not valid for GD2
 		}
 	}
 	return peersgd2, nil

--- a/pkg/glusterutils/types.go
+++ b/pkg/glusterutils/types.go
@@ -9,6 +9,7 @@ type Peer struct {
 	ID            string   `json:"id"`
 	PeerAddresses []string `json:"peer-addresses"`
 	Online        bool     `json:"online"`
+	Gd1State      int      // GD1 only
 }
 
 // Brick represents Gluster Brick


### PR DESCRIPTION
### Motivation

Our use case for `gluster-prometheus` is to monitor the health of our deployed GlusterD1 clusters. Since we're planning to deploy `gluster-prometheus` on OpenShift in pods separate from the `glusterfs-storage` pods, we plan to extract all the data that we require for metrics by using the `--remote-host` flag to connect to the GlusterD1 instances.

Therefore we need metrics that can tell us about the health of the cluster. Since we've seen cases in the past where peers would get stuck in odd states, we want to monitor `peer.state` which was not exposed by `Peer` in `pkg/glusterutils`.

### Changes

This merge request exposes `peer.state` when the exporter is running with the GD1 backend, and sets the value of `peer.state` to `-1` when running with the GD2 backend.

On top of this, we implement a new metrics module that provides cluster-level information about peers. We intentionally expose these cluster-level metrics for each peer in the cluster so we can perform sanity checks on the values by triggering alerts when values which should be identical diverge.