### PR TITLE
Brick-level metrics for all volumes in a cluster

### DIFF
--- a/gluster-exporter/metric_volume_status.go
+++ b/gluster-exporter/metric_volume_status.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"github.com/gluster/gluster-prometheus/pkg/glusterutils"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	volStatusBrickCountLabels = []MetricLabel{
+		{
+			Name: "instance",
+			Help: "Hostname of the gluster-prometheus instance providing this metric",
+		},
+		{
+			Name: "volume_name",
+			Help: "Name of the volume",
+		},
+	}
+	volStatusPerBrickLabels = []MetricLabel{
+		{
+			Name: "instance",
+			Help: "Hostname of the gluster-prometheus instance providing this metric",
+		},
+		{
+			Name: "volume_name",
+			Help: "Name of the volume",
+		},
+		{
+			Name: "hostname",
+			Help: "Hostname of the brick",
+		},
+		{
+			Name: "peerid",
+			Help: "Uuid of the peer hosting this brick",
+		},
+	}
+
+	volStatusGaugeVecs []*prometheus.GaugeVec
+
+	glusterVolStatusBrickCount = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_status_brick_count",
+		Help:      "Number of bricks for volume",
+		Labels:    volStatusBrickCountLabels,
+	}, &volStatusGaugeVecs)
+
+	glusterVolumeBrickStatus = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_brick_status",
+		Help:      "Per node brick status for volume",
+		Labels:    volStatusPerBrickLabels,
+	}, &volStatusGaugeVecs)
+
+	glusterVolumeBrickPort = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_brick_port",
+		Help:      "Brick port",
+		Labels:    volStatusPerBrickLabels,
+	}, &volStatusGaugeVecs)
+
+	glusterVolumeBrickPid = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_brick_pid",
+		Help:      "Brick pid",
+		Labels:    volStatusPerBrickLabels,
+	}, &volStatusGaugeVecs)
+
+	glusterVolumeBrickTotalInodes = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_brick_total_inodes",
+		Help:      "Brick total inodes",
+		Labels:    volStatusPerBrickLabels,
+	}, &volStatusGaugeVecs)
+
+	glusterVolumeBrickFreeInodes = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_brick_free_inodes",
+		Help:      "Brick free inodes",
+		Labels:    volStatusPerBrickLabels,
+	}, &volStatusGaugeVecs)
+
+	glusterVolumeBrickTotalBytes = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_brick_total_bytes",
+		Help:      "Brick total bytes",
+		Labels:    volStatusPerBrickLabels,
+	}, &volStatusGaugeVecs)
+
+	glusterVolumeBrickFreeBytes = newPrometheusGaugeVec(Metric{
+		Namespace: "gluster",
+		Name:      "volume_brick_free_bytes",
+		Help:      "Brick free bytes",
+		Labels:    volStatusPerBrickLabels,
+	}, &volStatusGaugeVecs)
+)
+
+func volumeInfo(gluster glusterutils.GInterface) (err error) {
+	// Reset all vecs to not export stale information
+	for _, gaugeVec := range volStatusGaugeVecs {
+		gaugeVec.Reset()
+	}
+
+	var peerID string
+
+	if gluster != nil {
+		if peerID, err = gluster.LocalPeerID(); err != nil {
+			return
+		}
+	}
+
+	volumes, err := gluster.VolumeStatus()
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{"peer": peerID}).Debug("[Gluster Volume Status] Error:", err)
+		return err
+	}
+
+	// Get monitored gluster instance FQDN
+	peers, err := gluster.Peers()
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{"peer": peerID}).Debug("[Gluster Volume Status] Error:", err)
+		return err
+	}
+	fqdn := "n/a"
+	for _, peer := range peers {
+		if peer.ID == peerID {
+			// TODO: figure out which value of PeerAddresses may
+			// be hostname -- or resolve ip ourselves
+			fqdn = peer.PeerAddresses[0]
+			break
+		}
+	}
+
+	for _, vol := range volumes {
+		brickCountLabels := prometheus.Labels{
+			"instance":    fqdn,
+			"volume_name": vol.Name,
+		}
+		glusterVolStatusBrickCount.With(brickCountLabels).Set(float64(len(vol.Nodes)))
+
+		for _, node := range vol.Nodes {
+			perBrickLabels := prometheus.Labels{
+				"instance":    fqdn,
+				"volume_name": vol.Name,
+				"hostname":    node.Hostname,
+				"peerid":      node.PeerID,
+			}
+			glusterVolumeBrickStatus.With(perBrickLabels).Set(float64(node.Status))
+			glusterVolumeBrickPort.With(perBrickLabels).Set(float64(node.Port))
+			glusterVolumeBrickPid.With(perBrickLabels).Set(float64(node.PID))
+
+			glusterVolumeBrickTotalInodes.With(perBrickLabels).Set(float64(node.Gd1InodesTotal))
+			glusterVolumeBrickFreeInodes.With(perBrickLabels).Set(float64(node.Gd1InodesFree))
+
+			glusterVolumeBrickTotalBytes.With(perBrickLabels).Set(float64(node.Capacity))
+			glusterVolumeBrickFreeBytes.With(perBrickLabels).Set(float64(node.Free))
+		}
+	}
+
+	return
+}
+
+func init() {
+	registerMetric("gluster_volume_status", volumeInfo)
+}

--- a/pkg/glusterutils/brick_status_gd1.go
+++ b/pkg/glusterutils/brick_status_gd1.go
@@ -7,7 +7,7 @@ import (
 // VolumeBrickStatus gets brick status info from glusterd2 using rest api
 func (g GD1) VolumeBrickStatus(vol string) ([]BrickStatus, error) {
 	// Run gluster volume status {vol}
-	out, err := g.execGluster("volume", "status", vol)
+	out, err := g.execGluster("volume", "status", vol, "detail")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/glusterutils/cache.go
+++ b/pkg/glusterutils/cache.go
@@ -289,6 +289,29 @@ func (gc *GCache) VolumeInfo() ([]Volume, error) {
 	return retVal, err
 }
 
+// VolumeStatus method wraps the GInterface.VolumeStatus call
+func (gc *GCache) VolumeStatus() ([]VolumeStatus, error) {
+	gc.lock.Lock()
+	defer gc.lock.Unlock()
+	// caching the results for each volume
+	const localName = "VolumeProfileStatus"
+	var retVal []VolumeStatus
+	var err error
+	var ok bool
+	if gc.timeForNewCall(localName, localName) {
+		if retVal, err = gc.gd.VolumeStatus(); err != nil {
+			return retVal, err
+		}
+		// reset the last called time only on a successful call
+		gc.lastCallTimeMap[localName] = time.Now()
+		gc.lastCallValueMap[localName] = retVal
+	}
+	if retVal, ok = gc.lastCallValueMap[localName].([]VolumeStatus); !ok {
+		err = errors.New("[CacheError] Unable to convert back to a valid return type")
+	}
+	return retVal, err
+}
+
 // VolumeProfileInfo method wraps the GInterface.VolumeProfileInfo call
 func (gc *GCache) VolumeProfileInfo(vol string) ([]ProfileInfo, error) {
 	gc.lock.Lock()

--- a/pkg/glusterutils/gd1.go
+++ b/pkg/glusterutils/gd1.go
@@ -56,6 +56,17 @@ type gd1Volumes struct {
 	List    []gd1Volume `xml:"volInfo>volumes>volume"`
 }
 
+type gd1VolumeStatusDetail struct {
+	Name      string       `xml:"volName"`
+	NodeCount int          `xml:"nodeCount"`
+	Nodes     []gd1Process `xml:"node"`
+}
+
+type gd1VolumesDetail struct {
+	XMLName xml.Name                `xml:"cliOutput"`
+	List    []gd1VolumeStatusDetail `xml:"volStatus>volumes>volume"`
+}
+
 type snapshotParentVolume struct {
 	Name          string `xml:"name"`
 	SnapCount     int    `xml:"snapCount"`
@@ -143,6 +154,10 @@ type gd1Process struct {
 	Port          string           `xml:"port"` // can contain 'N/A' entries
 	ProtocolPorts gd1ProtocolPorts `xml:"ports"`
 	PID           int              `xml:"pid"`
+	InodesTotal   uint64           `xml:"inodesTotal"`
+	InodesFree    uint64           `xml:"inodesFree"`
+	SizeTotal     uint64           `xml:"sizeTotal"`
+	SizeFree      uint64           `xml:"sizeFree"`
 }
 
 type gd1VolumeStatusInfo struct {

--- a/pkg/glusterutils/types.go
+++ b/pkg/glusterutils/types.go
@@ -52,6 +52,12 @@ type Volume struct {
 	ReplicaCount            int               `json:"replica-count"`
 }
 
+// VolumeStatus represents the detailed status of a Gluster volume
+type VolumeStatus struct {
+	Name  string
+	Nodes []BrickStatus
+}
+
 // HealEntry describe gluster heal info for each brick
 type HealEntry struct {
 	PeerID         string
@@ -70,12 +76,17 @@ type Snapshot struct {
 
 // BrickStatus describes the status details of volume brick
 type BrickStatus struct {
-	Hostname string
-	PeerID   string
-	Status   int
-	PID      int
-	Path     string
-	Volume   string
+	Hostname       string
+	PeerID         string
+	Status         int
+	PID            int
+	Port           int
+	Path           string
+	Volume         string
+	Capacity       uint64
+	Free           uint64
+	Gd1InodesFree  int64 // only valid with GD1, -1 with GD2
+	Gd1InodesTotal int64 // only valid with GD1, -1 with GD2
 }
 
 // GInterface should be implemented in GD1 and GD2 structs
@@ -90,6 +101,7 @@ type GInterface interface {
 	VolumeProfileInfo(vol string) ([]ProfileInfo, error)
 	VolumeBrickStatus(vol string) ([]BrickStatus, error)
 	EnableVolumeProfiling(volinfo Volume) error
+	VolumeStatus() ([]VolumeStatus, error)
 }
 
 // FopStat defines file ops related details

--- a/pkg/glusterutils/volstatus_gd1.go
+++ b/pkg/glusterutils/volstatus_gd1.go
@@ -1,0 +1,53 @@
+package glusterutils
+
+import (
+	"encoding/xml"
+	"strconv"
+)
+
+// VolumeStatus returns gluster vol status (glusterd)
+func (g *GD1) VolumeStatus() ([]VolumeStatus, error) {
+	// Run Gluster volume status all detail --xml --mode=script
+	out, err := g.execGluster("volume", "status", "all", "detail")
+	if err != nil {
+		return nil, err
+	}
+
+	var vols gd1VolumesDetail
+	err = xml.Unmarshal(out, &vols)
+	if err != nil {
+		return nil, err
+	}
+
+	outvols := make([]VolumeStatus, len(vols.List))
+	for vidx, vol := range vols.List {
+		outvol := VolumeStatus{
+			Name: vol.Name,
+		}
+		outvol.Nodes = make([]BrickStatus, len(vol.Nodes))
+		for nidx, node := range vol.Nodes {
+			port64, err := strconv.ParseInt(node.Port, 10, 32)
+			if err != nil {
+				port64 = -1
+			}
+			port := int(port64)
+			outnode := BrickStatus{
+				Hostname:       node.Hostname,
+				PeerID:         node.PeerID,
+				Status:         node.Status,
+				Port:           port,
+				PID:            node.PID,
+				Gd1InodesTotal: int64(node.InodesTotal),
+				Gd1InodesFree:  int64(node.InodesFree),
+				Capacity:       node.SizeTotal,
+				Free:           node.SizeFree,
+				Volume:         vol.Name,
+				Path:           node.Path,
+			}
+			outvol.Nodes[nidx] = outnode
+		}
+		outvols[vidx] = outvol
+	}
+
+	return outvols, nil
+}

--- a/pkg/glusterutils/volstatus_gd2.go
+++ b/pkg/glusterutils/volstatus_gd2.go
@@ -1,0 +1,48 @@
+package glusterutils
+
+// VolumeStatus returns gluster vol status (glusterd2)
+func (g *GD2) VolumeStatus() ([]VolumeStatus, error) {
+	client, err := initRESTClient(g.config)
+	if err != nil {
+		return nil, err
+	}
+	// We have to fetch the list of volumes first...
+	volumelist, err := client.Volumes("")
+	if err != nil {
+		return nil, err
+	}
+	volumestatus := make([]VolumeStatus, len(volumelist))
+	for idx, vol := range volumelist {
+		// ...and the detailed brick statuses individually for each
+		// volume, because the GD2 REST API does not have a "give me
+		// detailed status information for all volumes" endpoint.
+		brickstatusinfo, err := client.BricksStatus(vol.Name)
+		if err != nil {
+			return nil, err
+		}
+		brickstatus := make([]BrickStatus, len(brickstatusinfo))
+		for idx, info := range brickstatusinfo {
+			brickStatusObj := BrickStatus{
+				Hostname:       info.Info.Hostname,
+				PeerID:         info.Info.PeerID.String(),
+				PID:            info.Pid,
+				Port:           info.Port,
+				Path:           info.Info.Path,
+				Volume:         vol.Name,
+				Capacity:       info.Size.Capacity,
+				Free:           info.Size.Free,
+				Gd1InodesFree:  -1, // Inode data n/a in GD2 response
+				Gd1InodesTotal: -1, // Inode data n/a in GD2 response
+			}
+			if info.Online {
+				brickStatusObj.Status = 1
+			} else {
+				brickStatusObj.Status = 0
+			}
+			brickstatus[idx] = brickStatusObj
+		}
+		volumestatus[idx].Name = vol.Name
+		volumestatus[idx].Nodes = brickstatus
+	}
+	return volumestatus, nil
+}


### PR DESCRIPTION
### Motivation

We currently monitor various brick metrics in our GlusterD1 deployments. These metrics are based on the output of `gluster --mode=script --xml volume status all detail` and we would like to have these metrics available from `gluster-prometheus`.

### Changes

This merge request implements a new back end method `VolumeStatus` which produces a list of all the volumes in the cluster, where each record in the list contains a `BrickStatus` record for each brick of the volume.

The new metrics module then provides a number of metrics that we will use to implement alerts such as volumes running out of space or inodes, or volumes with offline bricks.