### PR TITLE
fix(metric_brick.go): fix in container where has volume hostPaht: /va…

### DIFF
--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -567,7 +567,7 @@ func lvmUsage(path string) (stats []LVMStat, thinPoolStats []ThinPoolStat, err e
 				continue
 			}
 			// Check if the logical volume is mounted as a gluster brick
-			if lv.Device == dev && strings.HasPrefix(path, mount.Name) {
+			if lv.Device == dev && strings.HasPrefix(path, mount.Name) && strings.Contains(path, lv.VGName) {
 				// Check if the LV is a thinly provisioned volume and if yes then get the thin pool LV name
 				if lv.Attr[0] == 'V' {
 					tpName := lv.PoolLV

--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -567,7 +567,7 @@ func lvmUsage(path string) (stats []LVMStat, thinPoolStats []ThinPoolStat, err e
 				continue
 			}
 			// Check if the logical volume is mounted as a gluster brick
-			if lv.Device == dev && strings.HasPrefix(path, mount.Name) && strings.Contains(path, lv.VGName) && strings.Contains(path, lv.Name) {
+			if lv.Device == dev && strings.HasPrefix(path, mount.Name) && strings.Contains(path, "/"+lv.VGName+"/"+lv.Name) {
 				// Check if the LV is a thinly provisioned volume and if yes then get the thin pool LV name
 				if lv.Attr[0] == 'V' {
 					tpName := lv.PoolLV

--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -567,7 +567,7 @@ func lvmUsage(path string) (stats []LVMStat, thinPoolStats []ThinPoolStat, err e
 				continue
 			}
 			// Check if the logical volume is mounted as a gluster brick
-			if lv.Device == dev && strings.HasPrefix(path, mount.Name) && strings.Contains(path, lv.VGName) {
+			if lv.Device == dev && strings.HasPrefix(path, mount.Name) && strings.Contains(path, lv.VGName) && strings.Contains(path, lv.Name) {
 				// Check if the LV is a thinly provisioned volume and if yes then get the thin pool LV name
 				if lv.Attr[0] == 'V' {
 					tpName := lv.PoolLV


### PR DESCRIPTION
- [ ] lgtm
i use this deployment : https://github.com/gluster/gluster-kubernetes/tree/master/deploy/kube-templates
in container has hostPath volume :/var/lib/heketi  .the gluster_brick_lv_xx metrics data are error.

![image](https://user-images.githubusercontent.com/20083081/58003718-f403de00-7b13-11e9-8f42-d15904f556e6.png)
the lv_path="/dev/cl/root" is hostPath, is not mount by brick_44dccc13b62936d5a756cfe98cd68369
