### PR TITLE
Gd1 optional remote host

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,10 @@ collectors related configurations.
 gluster-mgmt = "glusterd"
 glusterd-dir = "/var/lib/glusterd"
 gluster-binary-path = "gluster"
-gd1-remote-host = "localhost"
+# If you want to connect to a remote gd1 host, set the variable gd1-remote-host
+# However, using a remote host restrict the gluster cli to read-only commands
+# The following collectors won't work in remote mode : gluster_volume_counts, gluster_volume_profile 
+#gd1-remote-host = "localhost"
 gd2-rest-endpoint = "http://127.0.0.1:24007"
 port = 8080
 metrics-path = "/metrics"

--- a/extras/conf/gluster-exporter.toml.sample
+++ b/extras/conf/gluster-exporter.toml.sample
@@ -3,6 +3,10 @@ gluster-cluster-id = ""
 gluster-mgmt = "glusterd"
 glusterd-dir = "/var/lib/glusterd"
 gluster-binary-path = "gluster"
+# If you want to connect to a remote gd1 host, set the variable gd1-remote-host
+# However, using a remote host restrict the gluster cli to read-only commands
+# The following collectors won't work in remote mode : gluster_volume_counts, gluster_volume_profile 
+#gd1-remote-host = "localhost"
 gd2-rest-endpoint = "http://localhost:24007"
 port = 8080
 metrics-path = "/metrics"

--- a/pkg/glusterutils/common.go
+++ b/pkg/glusterutils/common.go
@@ -32,9 +32,6 @@ func setDefaultConfig(config *conf.GConfig) {
 	if config.GlusterCmd == "" {
 		config.GlusterCmd = "gluster"
 	}
-	if config.GlusterRemoteHost == "" {
-		config.GlusterRemoteHost = "localhost"
-	}
 	if config.Glusterd2Endpoint == "" {
 		config.Glusterd2Endpoint = "http://localhost:24007"
 	}

--- a/pkg/glusterutils/gd1.go
+++ b/pkg/glusterutils/gd1.go
@@ -210,6 +210,8 @@ func (g *GD1) execGluster(args ...string) ([]byte, error) {
 	// always request output in XML format
 	args = append(args, "--xml")
 	// grab remote host from config
-	args = append(args, fmt.Sprintf("--remote-host=%s", g.config.GlusterRemoteHost))
+	if g.config.GlusterRemoteHost != "" {
+		args = append(args, fmt.Sprintf("--remote-host=%s", g.config.GlusterRemoteHost))
+	}
 	return exec.Command(g.config.GlusterCmd, args...).Output()
 }


### PR DESCRIPTION
Instead of using `gd1-remote-host = "localhost"`, I've disabled the default value.
In the gd1 client, the `--remote-host` parameter is only used set if GlusterRemoteHost is set.

That way :

* the (I assume) basic use case of running the exporter on a glusterd node works fine without a `gd1-remote-host`
* using a remote-host is still possible

I've also added a few comments to highlight the using a `gd1-remote-host` will prevent from using `gluster_volume_counts` and `gluster_volume_profile`.

Fixes #151 