### PR TITLE
Added TTL to all Metrics exported

### DIFF
--- a/gluster-exporter/metric_brick.go
+++ b/gluster-exporter/metric_brick.go
@@ -142,9 +142,9 @@ var (
 		},
 	}
 
-	brickGaugeVecs []*prometheus.GaugeVec
+	brickGaugeVecs = make(map[string]*ExportedGaugeVec)
 
-	glusterBrickCapacityUsed = newPrometheusGaugeVec(Metric{
+	glusterBrickCapacityUsed = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_capacity_used_bytes",
 		Help:      "Used capacity of gluster bricks in bytes",
@@ -152,7 +152,7 @@ var (
 		Labels:    brickLabels,
 	}, &brickGaugeVecs)
 
-	glusterBrickCapacityFree = newPrometheusGaugeVec(Metric{
+	glusterBrickCapacityFree = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_capacity_free_bytes",
 		Help:      "Free capacity of gluster bricks in bytes",
@@ -160,7 +160,7 @@ var (
 		Labels:    brickLabels,
 	}, &brickGaugeVecs)
 
-	glusterBrickCapacityTotal = newPrometheusGaugeVec(Metric{
+	glusterBrickCapacityTotal = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_capacity_bytes_total",
 		Help:      "Total capacity of gluster bricks in bytes",
@@ -168,7 +168,7 @@ var (
 		Labels:    brickLabels,
 	}, &brickGaugeVecs)
 
-	glusterBrickInodesTotal = newPrometheusGaugeVec(Metric{
+	glusterBrickInodesTotal = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_inodes_total",
 		Help:      "Total no of inodes of gluster brick disk",
@@ -176,7 +176,7 @@ var (
 		Labels:    brickLabels,
 	}, &brickGaugeVecs)
 
-	glusterBrickInodesFree = newPrometheusGaugeVec(Metric{
+	glusterBrickInodesFree = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_inodes_free",
 		Help:      "Free no of inodes of gluster brick disk",
@@ -184,7 +184,7 @@ var (
 		Labels:    brickLabels,
 	}, &brickGaugeVecs)
 
-	glusterBrickInodesUsed = newPrometheusGaugeVec(Metric{
+	glusterBrickInodesUsed = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_inodes_used",
 		Help:      "Used no of inodes of gluster brick disk",
@@ -192,7 +192,7 @@ var (
 		Labels:    brickLabels,
 	}, &brickGaugeVecs)
 
-	glusterSubvolCapacityUsed = newPrometheusGaugeVec(Metric{
+	glusterSubvolCapacityUsed = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "subvol_capacity_used_bytes",
 		Help:      "Effective used capacity of gluster subvolume in bytes",
@@ -200,7 +200,7 @@ var (
 		Labels:    subvolLabels,
 	}, &brickGaugeVecs)
 
-	glusterSubvolCapacityTotal = newPrometheusGaugeVec(Metric{
+	glusterSubvolCapacityTotal = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "subvol_capacity_total_bytes",
 		Help:      "Effective total capacity of gluster subvolume in bytes",
@@ -208,7 +208,7 @@ var (
 		Labels:    subvolLabels,
 	}, &brickGaugeVecs)
 
-	glusterBrickLVSize = newPrometheusGaugeVec(Metric{
+	glusterBrickLVSize = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_lv_size_bytes",
 		Help:      "Bricks LV size Bytes",
@@ -216,7 +216,7 @@ var (
 		Labels:    lvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterBrickLVPercent = newPrometheusGaugeVec(Metric{
+	glusterBrickLVPercent = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_lv_percent",
 		Help:      "Bricks LV usage percent",
@@ -224,7 +224,7 @@ var (
 		Labels:    lvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterBrickLVMetadataSize = newPrometheusGaugeVec(Metric{
+	glusterBrickLVMetadataSize = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_lv_metadata_size_bytes",
 		Help:      "Bricks LV metadata size Bytes",
@@ -232,7 +232,7 @@ var (
 		Labels:    lvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterBrickLVMetadataPercent = newPrometheusGaugeVec(Metric{
+	glusterBrickLVMetadataPercent = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_lv_metadata_percent",
 		Help:      "Bricks LV metadata usage percent",
@@ -240,7 +240,7 @@ var (
 		Labels:    lvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterVGExtentTotal = newPrometheusGaugeVec(Metric{
+	glusterVGExtentTotal = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "vg_extent_total_count",
 		Help:      "VG extent total count ",
@@ -248,7 +248,7 @@ var (
 		Labels:    lvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterVGExtentAlloc = newPrometheusGaugeVec(Metric{
+	glusterVGExtentAlloc = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "vg_extent_alloc_count",
 		Help:      "VG extent allocated count ",
@@ -256,7 +256,7 @@ var (
 		Labels:    lvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterThinPoolDataTotal = newPrometheusGaugeVec(Metric{
+	glusterThinPoolDataTotal = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "thinpool_data_total_bytes",
 		Help:      "Thin pool size Bytes",
@@ -264,7 +264,7 @@ var (
 		Labels:    thinLvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterThinPoolDataUsed = newPrometheusGaugeVec(Metric{
+	glusterThinPoolDataUsed = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "thinpool_data_used_bytes",
 		Help:      "Thin pool data used Bytes",
@@ -272,7 +272,7 @@ var (
 		Labels:    thinLvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterThinPoolMetadataTotal = newPrometheusGaugeVec(Metric{
+	glusterThinPoolMetadataTotal = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "thinpool_metadata_total_bytes",
 		Help:      "Thin pool metadata size Bytes",
@@ -280,7 +280,7 @@ var (
 		Labels:    thinLvmLbls,
 	}, &brickGaugeVecs)
 
-	glusterThinPoolMetadataUsed = newPrometheusGaugeVec(Metric{
+	glusterThinPoolMetadataUsed = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "thinpool_metadata_used_bytes",
 		Help:      "Thin pool metadata used Bytes",
@@ -288,9 +288,9 @@ var (
 		Labels:    thinLvmLbls,
 	}, &brickGaugeVecs)
 
-	brickStatusGaugeVecs []*prometheus.GaugeVec
+	brickStatusGaugeVecs = make(map[string]*ExportedGaugeVec)
 
-	glusterBrickUp = newPrometheusGaugeVec(Metric{
+	glusterBrickUp = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "brick_up",
 		Help:      "Brick up (1-up, 0-down)",
@@ -592,7 +592,7 @@ func lvmUsage(path string) (stats []LVMStat, thinPoolStats []ThinPoolStat, err e
 func brickUtilization(gluster glusterutils.GInterface) error {
 	// Reset all vecs to not export stale information
 	for _, gaugeVec := range brickGaugeVecs {
-		gaugeVec.Reset()
+		gaugeVec.RemoveStaleMetrics()
 	}
 
 	volumes, err := gluster.VolumeInfo()
@@ -631,12 +631,12 @@ func brickUtilization(gluster glusterutils.GInterface) error {
 					}
 					var lbls = getGlusterBrickLabels(brick, subvol.Name)
 					// Update the metrics
-					glusterBrickCapacityUsed.With(lbls).Set(usage.Used)
-					glusterBrickCapacityFree.With(lbls).Set(usage.Free)
-					glusterBrickCapacityTotal.With(lbls).Set(usage.All)
-					glusterBrickInodesTotal.With(lbls).Set(usage.InodesAll)
-					glusterBrickInodesFree.With(lbls).Set(usage.InodesFree)
-					glusterBrickInodesUsed.With(lbls).Set(usage.InodesUsed)
+					brickGaugeVecs[glusterBrickCapacityUsed].Set(lbls, usage.Used)
+					brickGaugeVecs[glusterBrickCapacityFree].Set(lbls, usage.Free)
+					brickGaugeVecs[glusterBrickCapacityTotal].Set(lbls, usage.All)
+					brickGaugeVecs[glusterBrickInodesTotal].Set(lbls, usage.InodesAll)
+					brickGaugeVecs[glusterBrickInodesFree].Set(lbls, usage.InodesFree)
+					brickGaugeVecs[glusterBrickInodesUsed].Set(lbls, usage.InodesUsed)
 					// Skip exporting utilization data in case of arbiter
 					// brick to avoid wrong values when both the data bricks
 					// are down
@@ -661,20 +661,20 @@ func brickUtilization(gluster glusterutils.GInterface) error {
 					for _, stat := range stats {
 						var lvmLbls = getGlusterLVMLabels(brick, subvol.Name, stat)
 						// Convert to bytes
-						glusterBrickLVSize.With(lvmLbls).Set(stat.Size * 1024 * 1024)
-						glusterBrickLVPercent.With(lvmLbls).Set(stat.DataPercent)
+						brickGaugeVecs[glusterBrickLVSize].Set(lvmLbls, stat.Size*1024*1024)
+						brickGaugeVecs[glusterBrickLVPercent].Set(lvmLbls, stat.DataPercent)
 						// Convert to bytes
-						glusterBrickLVMetadataSize.With(lvmLbls).Set(stat.MetadataSize * 1024 * 1024)
-						glusterBrickLVMetadataPercent.With(lvmLbls).Set(stat.MetadataPercent)
-						glusterVGExtentTotal.With(lvmLbls).Set(stat.VGExtentTotal)
-						glusterVGExtentAlloc.With(lvmLbls).Set(stat.VGExtentAlloc)
+						brickGaugeVecs[glusterBrickLVMetadataSize].Set(lvmLbls, stat.MetadataSize*1024*1024)
+						brickGaugeVecs[glusterBrickLVMetadataPercent].Set(lvmLbls, stat.MetadataPercent)
+						brickGaugeVecs[glusterVGExtentTotal].Set(lvmLbls, stat.VGExtentTotal)
+						brickGaugeVecs[glusterVGExtentAlloc].Set(lvmLbls, stat.VGExtentAlloc)
 					}
 					for _, thinStat := range thinStats {
 						var thinLvmLbls = getGlusterThinPoolLabels(brick, volume.Name, subvol.Name, thinStat)
-						glusterThinPoolDataTotal.With(thinLvmLbls).Set(thinStat.ThinPoolDataTotal * 1024 * 1024)
-						glusterThinPoolDataUsed.With(thinLvmLbls).Set(thinStat.ThinPoolDataUsed * 1024 * 1024)
-						glusterThinPoolMetadataTotal.With(thinLvmLbls).Set(thinStat.ThinPoolMetadataTotal * 1024 * 1024)
-						glusterThinPoolMetadataUsed.With(thinLvmLbls).Set(thinStat.ThinPoolMetadataUsed * 1024 * 1024)
+						brickGaugeVecs[glusterThinPoolDataTotal].Set(thinLvmLbls, thinStat.ThinPoolDataTotal*1024*1024)
+						brickGaugeVecs[glusterThinPoolDataUsed].Set(thinLvmLbls, thinStat.ThinPoolDataUsed*1024*1024)
+						brickGaugeVecs[glusterThinPoolMetadataTotal].Set(thinLvmLbls, thinStat.ThinPoolMetadataTotal*1024*1024)
+						brickGaugeVecs[glusterThinPoolMetadataUsed].Set(thinLvmLbls, thinStat.ThinPoolMetadataUsed*1024*1024)
 					}
 				}
 			}
@@ -692,10 +692,10 @@ func brickUtilization(gluster glusterutils.GInterface) error {
 			// contains only arbiter brick on current node or no local bricks on
 			// this node
 			if effectiveCapacity > 0 {
-				glusterSubvolCapacityUsed.With(subvolLabels).Set(effectiveCapacity)
+				brickGaugeVecs[glusterSubvolCapacityUsed].Set(subvolLabels, effectiveCapacity)
 			}
 			if effectiveTotalCapacity > 0 {
-				glusterSubvolCapacityTotal.With(subvolLabels).Set(effectiveTotalCapacity)
+				brickGaugeVecs[glusterSubvolCapacityTotal].Set(subvolLabels, effectiveTotalCapacity)
 			}
 		}
 	}
@@ -716,7 +716,7 @@ func getBrickStatusLabels(vol string, host string, brickPath string, peerID stri
 func brickStatus(gluster glusterutils.GInterface) error {
 	// Reset all vecs to not export stale information
 	for _, gaugeVec := range brickStatusGaugeVecs {
-		gaugeVec.Reset()
+		gaugeVec.RemoveStaleMetrics()
 	}
 
 	isLeader, err := gluster.IsLeader()
@@ -763,7 +763,7 @@ func brickStatus(gluster glusterutils.GInterface) error {
 		}
 		for _, entry := range brickStatus {
 			labels := getBrickStatusLabels(volume.Name, entry.Hostname, entry.Path, entry.PeerID, entry.PID)
-			glusterBrickUp.With(labels).Set(float64(entry.Status))
+			brickStatusGaugeVecs[glusterBrickUp].Set(labels, float64(entry.Status))
 		}
 	}
 

--- a/gluster-exporter/metric_peers.go
+++ b/gluster-exporter/metric_peers.go
@@ -28,23 +28,23 @@ var (
 		},
 	}
 
-	peerGaugeVecs []*prometheus.GaugeVec
+	peerGaugeVecs = make(map[string]*ExportedGaugeVec)
 
-	glusterPeerCount = newPrometheusGaugeVec(Metric{
+	glusterPeerCount = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "peer_count",
 		Help:      "Number of peers in cluster",
 		Labels:    peerCountMetricLabels,
 	}, &peerGaugeVecs)
 
-	glusterPeerStatus = newPrometheusGaugeVec(Metric{
+	glusterPeerStatus = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "peer_status",
 		Help:      "Peer status info",
 		Labels:    peerSCMetricLabels,
 	}, &peerGaugeVecs)
 
-	glusterPeerConnected = newPrometheusGaugeVec(Metric{
+	glusterPeerConnected = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "peer_connected",
 		Help:      "Peer connection status",
@@ -55,7 +55,7 @@ var (
 func peerInfo(gluster glusterutils.GInterface) (err error) {
 	// Reset all vecs to not export stale information
 	for _, gaugeVec := range peerGaugeVecs {
-		gaugeVec.Reset()
+		gaugeVec.RemoveStaleMetrics()
 	}
 
 	var peerID string
@@ -85,7 +85,7 @@ func peerInfo(gluster glusterutils.GInterface) (err error) {
 		"instance": fqdn,
 	}
 
-	glusterPeerCount.With(peerCountLabels).Set(float64(len(peers)))
+	peerGaugeVecs[glusterPeerCount].Set(peerCountLabels, float64(len(peers)))
 
 	var connected int
 	for _, peer := range peers {
@@ -103,9 +103,9 @@ func peerInfo(gluster glusterutils.GInterface) (err error) {
 		// non-negative peer state, i.e. we're running with the GD1
 		// backend.
 		if peer.Gd1State > -1 {
-			glusterPeerStatus.With(peerSCLabels).Set(float64(peer.Gd1State))
+			peerGaugeVecs[glusterPeerStatus].Set(peerSCLabels, float64(peer.Gd1State))
 		}
-		glusterPeerConnected.With(peerSCLabels).Set(float64(connected))
+		peerGaugeVecs[glusterPeerConnected].Set(peerSCLabels, float64(connected))
 	}
 
 	return

--- a/gluster-exporter/metric_volume.go
+++ b/gluster-exporter/metric_volume.go
@@ -28,9 +28,9 @@ var (
 		},
 	}
 
-	volumeHealGaugeVecs []*prometheus.GaugeVec
+	volumeHealGaugeVecs = make(map[string]*ExportedGaugeVec)
 
-	glusterVolumeHealCount = newPrometheusGaugeVec(Metric{
+	glusterVolumeHealCount = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_heal_count",
 		Help:      "self heal count for volume",
@@ -38,7 +38,7 @@ var (
 		Labels:    volumeHealLabels,
 	}, &volumeHealGaugeVecs)
 
-	glusterVolumeSplitBrainHealCount = newPrometheusGaugeVec(Metric{
+	glusterVolumeSplitBrainHealCount = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_split_brain_heal_count",
 		Help:      "self heal count for volume in split brain",
@@ -58,9 +58,9 @@ var (
 		},
 	}
 
-	volumeProfileGaugeVecs []*prometheus.GaugeVec
+	volumeProfileGaugeVecs = make(map[string]*ExportedGaugeVec)
 
-	glusterVolumeProfileTotalReads = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileTotalReads = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_total_reads",
 		Help:      "Total no of reads",
@@ -68,7 +68,7 @@ var (
 		Labels:    volumeProfileInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileTotalWrites = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileTotalWrites = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_total_writes",
 		Help:      "Total no of writes",
@@ -76,7 +76,7 @@ var (
 		Labels:    volumeProfileInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileDuration = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileDuration = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_duration_secs",
 		Help:      "Duration",
@@ -84,7 +84,7 @@ var (
 		Labels:    volumeProfileInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileTotalReadsInt = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileTotalReadsInt = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_total_reads_interval",
 		Help:      "Total no of reads for interval stats",
@@ -92,7 +92,7 @@ var (
 		Labels:    volumeProfileInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileTotalWritesInt = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileTotalWritesInt = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_total_writes_interval",
 		Help:      "Total no of writes for interval stats",
@@ -100,7 +100,7 @@ var (
 		Labels:    volumeProfileInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileDurationInt = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileDurationInt = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_duration_secs_interval",
 		Help:      "Duration for interval stats",
@@ -128,7 +128,7 @@ var (
 		},
 	}
 
-	glusterVolumeProfileFopHits = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopHits = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_hits",
 		Help:      "Cumulative FOP hits",
@@ -136,7 +136,7 @@ var (
 		Labels:    volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopAvgLatency = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopAvgLatency = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_avg_latency",
 		Help:      "Cumulative FOP avergae latency",
@@ -144,7 +144,7 @@ var (
 		Labels:    volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopMinLatency = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopMinLatency = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_min_latency",
 		Help:      "Cumulative FOP min latency",
@@ -152,7 +152,7 @@ var (
 		Labels:    volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopMaxLatency = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopMaxLatency = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_max_latency",
 		Help:      "Cumulative FOP max latency",
@@ -160,7 +160,7 @@ var (
 		Labels:    volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopHitsInt = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopHitsInt = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_hits_interval",
 		Help:      "Interval based FOP hits",
@@ -168,7 +168,7 @@ var (
 		Labels:    volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopAvgLatencyInt = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopAvgLatencyInt = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_avg_latency_interval",
 		Help:      "Interval based FOP average latency",
@@ -176,7 +176,7 @@ var (
 		Labels:    volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopMinLatencyInt = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopMinLatencyInt = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_min_latency_interval",
 		Help:      "Interval based FOP min latency",
@@ -184,7 +184,7 @@ var (
 		Labels:    volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopMaxLatencyInt = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopMaxLatencyInt = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_max_latency_interval",
 		Help:      "Interval based FOP max latency",
@@ -192,7 +192,7 @@ var (
 		Labels:    volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopTotalHitsAggregatedOps = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopTotalHitsAggregatedOps = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_total_hits_on_aggregated_fops",
 		Help: "Cumulative total hits on aggregated FOPs" +
@@ -201,7 +201,7 @@ var (
 		Labels:   volumeProfileFopInfoLabels,
 	}, &volumeProfileGaugeVecs)
 
-	glusterVolumeProfileFopTotalHitsAggregatedOpsInt = newPrometheusGaugeVec(Metric{
+	glusterVolumeProfileFopTotalHitsAggregatedOpsInt = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_profile_fop_total_hits_on_aggregated_fops_interval",
 		Help: "Interval based total hits on aggregated FOPs" +
@@ -315,7 +315,7 @@ func healCounts(gluster glusterutils.GInterface) error {
 
 	// Reset all vecs to not export stale information
 	for _, gaugeVec := range volumeHealGaugeVecs {
-		gaugeVec.Reset()
+		gaugeVec.RemoveStaleMetrics()
 	}
 
 	if err != nil {
@@ -339,7 +339,7 @@ func healCounts(gluster glusterutils.GInterface) error {
 	// (can be either 'glusterVolumeHealCount' or 'glusterVolumeSplitBrainHealCount')
 	// arg3: volName a string representing the volume name
 	// arg4: errStr the error string in case of error
-	locHealInfoFunc := func(f1 func(string) ([]glusterutils.HealEntry, error), gVect *prometheus.GaugeVec, volName string, errStr string) {
+	locHealInfoFunc := func(f1 func(string) ([]glusterutils.HealEntry, error), gVect string, volName string, errStr string) {
 		// Get the heal count
 		heals, err := f1(volName)
 		if err != nil {
@@ -350,7 +350,7 @@ func healCounts(gluster glusterutils.GInterface) error {
 		}
 		for _, healinfo := range heals {
 			labels := getVolumeHealLabels(volName, healinfo.Hostname, healinfo.Brick)
-			gVect.With(labels).Set(float64(healinfo.NumHealEntries))
+			volumeHealGaugeVecs[gVect].Set(labels, float64(healinfo.NumHealEntries))
 		}
 	}
 
@@ -400,7 +400,7 @@ func getBrickHost(vol glusterutils.Volume, brickname string) string {
 func profileInfo(gluster glusterutils.GInterface) error {
 	// Reset all vecs to not export stale information
 	for _, gaugeVec := range volumeProfileGaugeVecs {
-		gaugeVec.Reset()
+		gaugeVec.RemoveStaleMetrics()
 	}
 
 	isLeader, err := gluster.IsLeader()
@@ -453,32 +453,32 @@ func profileInfo(gluster glusterutils.GInterface) error {
 		}
 		for _, entry := range profileinfo {
 			labels := getVolumeProfileInfoLabels(name, entry.BrickName)
-			glusterVolumeProfileTotalReads.With(labels).Set(float64(entry.TotalReads))
-			glusterVolumeProfileTotalWrites.With(labels).Set(float64(entry.TotalWrites))
-			glusterVolumeProfileDuration.With(labels).Set(float64(entry.Duration))
-			glusterVolumeProfileTotalReadsInt.With(labels).Set(float64(entry.TotalReadsInt))
-			glusterVolumeProfileTotalWritesInt.With(labels).Set(float64(entry.TotalWritesInt))
-			glusterVolumeProfileDurationInt.With(labels).Set(float64(entry.DurationInt))
+			volumeProfileGaugeVecs[glusterVolumeProfileTotalReads].Set(labels, float64(entry.TotalReads))
+			volumeProfileGaugeVecs[glusterVolumeProfileTotalWrites].Set(labels, float64(entry.TotalWrites))
+			volumeProfileGaugeVecs[glusterVolumeProfileDuration].Set(labels, float64(entry.Duration))
+			volumeProfileGaugeVecs[glusterVolumeProfileTotalReadsInt].Set(labels, float64(entry.TotalReadsInt))
+			volumeProfileGaugeVecs[glusterVolumeProfileTotalWritesInt].Set(labels, float64(entry.TotalWritesInt))
+			volumeProfileGaugeVecs[glusterVolumeProfileDurationInt].Set(labels, float64(entry.DurationInt))
 			brickhost := getBrickHost(volume, entry.BrickName)
 			for _, eachOp := range aggregatedOps {
 				fopLbls := getVolumeProfileFopInfoLabels(name, entry.BrickName,
 					brickhost, eachOp.String())
-				glusterVolumeProfileFopTotalHitsAggregatedOps.With(fopLbls).Set(eachOp.opHits(entry.FopStats))
-				glusterVolumeProfileFopTotalHitsAggregatedOpsInt.With(fopLbls).Set(eachOp.opHits(entry.FopStatsInt))
+				volumeProfileGaugeVecs[glusterVolumeProfileFopTotalHitsAggregatedOps].Set(fopLbls, eachOp.opHits(entry.FopStats))
+				volumeProfileGaugeVecs[glusterVolumeProfileFopTotalHitsAggregatedOpsInt].Set(fopLbls, eachOp.opHits(entry.FopStatsInt))
 			}
 			for _, fopInfo := range entry.FopStats {
 				fopLbls := getVolumeProfileFopInfoLabels(name, entry.BrickName, brickhost, fopInfo.Name)
-				glusterVolumeProfileFopHits.With(fopLbls).Set(float64(fopInfo.Hits))
-				glusterVolumeProfileFopAvgLatency.With(fopLbls).Set(fopInfo.AvgLatency)
-				glusterVolumeProfileFopMinLatency.With(fopLbls).Set(fopInfo.MinLatency)
-				glusterVolumeProfileFopMaxLatency.With(fopLbls).Set(fopInfo.MaxLatency)
+				volumeProfileGaugeVecs[glusterVolumeProfileFopHits].Set(fopLbls, float64(fopInfo.Hits))
+				volumeProfileGaugeVecs[glusterVolumeProfileFopAvgLatency].Set(fopLbls, fopInfo.AvgLatency)
+				volumeProfileGaugeVecs[glusterVolumeProfileFopMinLatency].Set(fopLbls, fopInfo.MinLatency)
+				volumeProfileGaugeVecs[glusterVolumeProfileFopMaxLatency].Set(fopLbls, fopInfo.MaxLatency)
 			}
 			for _, fopInfo := range entry.FopStatsInt {
 				fopLbls := getVolumeProfileFopInfoLabels(name, entry.BrickName, brickhost, fopInfo.Name)
-				glusterVolumeProfileFopHitsInt.With(fopLbls).Set(float64(fopInfo.Hits))
-				glusterVolumeProfileFopAvgLatencyInt.With(fopLbls).Set(fopInfo.AvgLatency)
-				glusterVolumeProfileFopMinLatencyInt.With(fopLbls).Set(fopInfo.MinLatency)
-				glusterVolumeProfileFopMaxLatencyInt.With(fopLbls).Set(fopInfo.MaxLatency)
+				volumeProfileGaugeVecs[glusterVolumeProfileFopHitsInt].Set(fopLbls, float64(fopInfo.Hits))
+				volumeProfileGaugeVecs[glusterVolumeProfileFopAvgLatencyInt].Set(fopLbls, fopInfo.AvgLatency)
+				volumeProfileGaugeVecs[glusterVolumeProfileFopMinLatencyInt].Set(fopLbls, fopInfo.MinLatency)
+				volumeProfileGaugeVecs[glusterVolumeProfileFopMaxLatencyInt].Set(fopLbls, fopInfo.MaxLatency)
 			}
 		}
 	}

--- a/gluster-exporter/metric_volume_status.go
+++ b/gluster-exporter/metric_volume_status.go
@@ -36,58 +36,58 @@ var (
 		},
 	}
 
-	volStatusGaugeVecs []*prometheus.GaugeVec
+	volStatusGaugeVecs = make(map[string]*ExportedGaugeVec)
 
-	glusterVolStatusBrickCount = newPrometheusGaugeVec(Metric{
+	glusterVolStatusBrickCount = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_status_brick_count",
 		Help:      "Number of bricks for volume",
 		Labels:    volStatusBrickCountLabels,
 	}, &volStatusGaugeVecs)
 
-	glusterVolumeBrickStatus = newPrometheusGaugeVec(Metric{
+	glusterVolumeBrickStatus = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_brick_status",
 		Help:      "Per node brick status for volume",
 		Labels:    volStatusPerBrickLabels,
 	}, &volStatusGaugeVecs)
 
-	glusterVolumeBrickPort = newPrometheusGaugeVec(Metric{
+	glusterVolumeBrickPort = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_brick_port",
 		Help:      "Brick port",
 		Labels:    volStatusPerBrickLabels,
 	}, &volStatusGaugeVecs)
 
-	glusterVolumeBrickPid = newPrometheusGaugeVec(Metric{
+	glusterVolumeBrickPid = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_brick_pid",
 		Help:      "Brick pid",
 		Labels:    volStatusPerBrickLabels,
 	}, &volStatusGaugeVecs)
 
-	glusterVolumeBrickTotalInodes = newPrometheusGaugeVec(Metric{
+	glusterVolumeBrickTotalInodes = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_brick_total_inodes",
 		Help:      "Brick total inodes",
 		Labels:    volStatusPerBrickLabels,
 	}, &volStatusGaugeVecs)
 
-	glusterVolumeBrickFreeInodes = newPrometheusGaugeVec(Metric{
+	glusterVolumeBrickFreeInodes = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_brick_free_inodes",
 		Help:      "Brick free inodes",
 		Labels:    volStatusPerBrickLabels,
 	}, &volStatusGaugeVecs)
 
-	glusterVolumeBrickTotalBytes = newPrometheusGaugeVec(Metric{
+	glusterVolumeBrickTotalBytes = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_brick_total_bytes",
 		Help:      "Brick total bytes",
 		Labels:    volStatusPerBrickLabels,
 	}, &volStatusGaugeVecs)
 
-	glusterVolumeBrickFreeBytes = newPrometheusGaugeVec(Metric{
+	glusterVolumeBrickFreeBytes = registerExportedGaugeVec(Metric{
 		Namespace: "gluster",
 		Name:      "volume_brick_free_bytes",
 		Help:      "Brick free bytes",
@@ -98,7 +98,7 @@ var (
 func volumeInfo(gluster glusterutils.GInterface) (err error) {
 	// Reset all vecs to not export stale information
 	for _, gaugeVec := range volStatusGaugeVecs {
-		gaugeVec.Reset()
+		gaugeVec.RemoveStaleMetrics()
 	}
 
 	var peerID string
@@ -136,7 +136,7 @@ func volumeInfo(gluster glusterutils.GInterface) (err error) {
 			"instance":    fqdn,
 			"volume_name": vol.Name,
 		}
-		glusterVolStatusBrickCount.With(brickCountLabels).Set(float64(len(vol.Nodes)))
+		volStatusGaugeVecs[glusterVolStatusBrickCount].Set(brickCountLabels, float64(len(vol.Nodes)))
 
 		for _, node := range vol.Nodes {
 			perBrickLabels := prometheus.Labels{
@@ -145,15 +145,15 @@ func volumeInfo(gluster glusterutils.GInterface) (err error) {
 				"hostname":    node.Hostname,
 				"peerid":      node.PeerID,
 			}
-			glusterVolumeBrickStatus.With(perBrickLabels).Set(float64(node.Status))
-			glusterVolumeBrickPort.With(perBrickLabels).Set(float64(node.Port))
-			glusterVolumeBrickPid.With(perBrickLabels).Set(float64(node.PID))
+			volStatusGaugeVecs[glusterVolumeBrickStatus].Set(perBrickLabels, float64(node.Status))
+			volStatusGaugeVecs[glusterVolumeBrickPort].Set(perBrickLabels, float64(node.Port))
+			volStatusGaugeVecs[glusterVolumeBrickPid].Set(perBrickLabels, float64(node.PID))
 
-			glusterVolumeBrickTotalInodes.With(perBrickLabels).Set(float64(node.Gd1InodesTotal))
-			glusterVolumeBrickFreeInodes.With(perBrickLabels).Set(float64(node.Gd1InodesFree))
+			volStatusGaugeVecs[glusterVolumeBrickTotalInodes].Set(perBrickLabels, float64(node.Gd1InodesTotal))
+			volStatusGaugeVecs[glusterVolumeBrickFreeInodes].Set(perBrickLabels, float64(node.Gd1InodesFree))
 
-			glusterVolumeBrickTotalBytes.With(perBrickLabels).Set(float64(node.Capacity))
-			glusterVolumeBrickFreeBytes.With(perBrickLabels).Set(float64(node.Free))
+			volStatusGaugeVecs[glusterVolumeBrickTotalBytes].Set(perBrickLabels, float64(node.Capacity))
+			volStatusGaugeVecs[glusterVolumeBrickFreeBytes].Set(perBrickLabels, float64(node.Free))
 		}
 	}
 

--- a/gluster-exporter/metrics.go
+++ b/gluster-exporter/metrics.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 )
 
 // MetricLabel represents Prometheus Label
@@ -18,6 +21,7 @@ type Metric struct {
 	Namespace string
 	Disabled  bool
 	Labels    []MetricLabel
+	TTL       time.Duration
 }
 
 // LabelNames returns list of Prometheus labels
@@ -29,12 +33,29 @@ func (m *Metric) LabelNames() []string {
 	return out
 }
 
-// newPrometheusGaugeVec is wrapper around prometheus.NewGaugeVec. Additionally
-// it registers with global map which can be used for documentation,
-// listing supported metrics via CLI etc.
-// 'gaugeVecArrPtr' helps to collect all the 'GaugeVec' pertaining to a metric
-// group.  Ignored if 'nil'
-func newPrometheusGaugeVec(m Metric, gaugeVecArrPtr *[]*prometheus.GaugeVec) *prometheus.GaugeVec {
+var metrics []Metric
+var defaultMetricTTL = 2 * time.Minute
+
+// MetricWithTTL represents the metric with label combinations
+// and Last updated time details
+type MetricWithTTL struct {
+	LastUpdated time.Time
+	Labels      prometheus.Labels
+}
+
+// ExportedGaugeVec represents each GaugeVec with additional information
+type ExportedGaugeVec struct {
+	Namespace string
+	Name      string
+	Help      string
+	LongHelp  string
+	Labels    []string
+	GaugeVec  *prometheus.GaugeVec
+	Metrics   map[uint64]MetricWithTTL
+	TTL       time.Duration
+}
+
+func registerExportedGaugeVec(m Metric, exported *map[string]*ExportedGaugeVec) string {
 	gaugeVec := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: m.Namespace,
@@ -46,15 +67,55 @@ func newPrometheusGaugeVec(m Metric, gaugeVecArrPtr *[]*prometheus.GaugeVec) *pr
 
 	// Register the metric with Prometheus
 	prometheus.MustRegister(gaugeVec)
-
-	if gaugeVecArrPtr != nil {
-		*gaugeVecArrPtr = append(*gaugeVecArrPtr, gaugeVec)
+	ttl := m.TTL
+	if ttl == 0 {
+		ttl = defaultMetricTTL
 	}
 
 	// Add the metric to the global queue
 	metrics = append(metrics, m)
 
-	return gaugeVec
+	(*exported)[m.Name] = &ExportedGaugeVec{
+		Namespace: m.Namespace,
+		Name:      m.Name,
+		Help:      m.Help,
+		LongHelp:  m.LongHelp,
+		Labels:    m.LabelNames(),
+		GaugeVec:  gaugeVec,
+		Metrics:   make(map[uint64]MetricWithTTL),
+		TTL:       ttl,
+	}
+	return m.Name
 }
 
-var metrics []Metric
+func (gv *ExportedGaugeVec) setMetricLastUpdated(labels prometheus.Labels) {
+	if gv.TTL > 0 {
+		// Get hash value of Metric labels
+		hash := model.LabelsToSignature(labels)
+		gv.Metrics[hash] = MetricWithTTL{
+			LastUpdated: time.Now(),
+			Labels:      labels,
+		}
+	}
+}
+
+// RemoveStaleMetrics removes all the stale metrics which are not
+// exported for TTL period.
+func (gv *ExportedGaugeVec) RemoveStaleMetrics() {
+	if gv.TTL == 0 {
+		return
+	}
+
+	now := time.Now()
+	for _, metric := range gv.Metrics {
+		if metric.LastUpdated.Add(gv.TTL).Before(now) {
+			gv.GaugeVec.Delete(metric.Labels)
+		}
+	}
+}
+
+// Set updates the Gauge Value and last update time
+func (gv *ExportedGaugeVec) Set(labels prometheus.Labels, value float64) {
+	gv.GaugeVec.With(labels).Set(value)
+	gv.setMetricLastUpdated(labels)
+}


### PR DESCRIPTION
Reseting all metrics causes missing entries since the Prometheus
server may pull the metrics from exporter when it was reset.
To avoid the problem, TTL option is provided(Default is 2 minutes).

If a Metric is not exported for the TTL period, then it deletes
that metric from exporter to avoid stale entries.

Fixes: #158
Signed-off-by: Aravinda VK <avishwan@redhat.com>