### PR TITLE
fix infinite fork loop when dep fails in 'make vendor-install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ vendor-update:
 
 vendor-install:
 	@echo Installing vendored packages
+	@if test $(MAKELEVEL) -gt 5; then echo Aborting to avoid infinite forks; exit 1; fi
 	@$(DEPENV) dep ensure -v -vendor-only || $(MAKE) vendor-install
 	@echo
 


### PR DESCRIPTION
In #164, a `|| $(MAKE) vendor-install` was added to the `vendor-install` target to help with "poor network circumstances":
https://github.com/gluster/gluster-prometheus/blob/3ebaacc2c690223f77fc93f5f237ab5065138660/Makefile#L82-L85

However, this leads to an infinite fork loop when `dep` fails or is not installed, possibly crashing the host machine.

This PR works around the infinite loop by checking the MAKELEVEL and aborting if it gets too high, which still allows the command to be retried a reasonable number of times.
Another possible approach is just looping around `dep` a set number of times.

Fixes #195.